### PR TITLE
Mac os x support

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -35,7 +35,14 @@ show_agent_output() {
 OPTIND=1
 SCRIPT_DIR=$(dirname $0)
 JATTACH=$SCRIPT_DIR/build/jattach
-PROFILER=$SCRIPT_DIR/build/libasyncProfiler.so
+UNAME_S=$(uname -s)
+if [ "$UNAME_S" == "Darwin" ]; then
+    # jattach will make realpath call for mac os x
+    PROFILER=$SCRIPT_DIR/build/libasyncProfiler.so
+else
+    PROFILER=$(readlink -f $SCRIPT_DIR/build/libasyncProfiler.so)
+fi
+
 ACTION="collect"
 MODE="cpu"
 DURATION="60"

--- a/profiler.sh
+++ b/profiler.sh
@@ -37,8 +37,8 @@ SCRIPT_DIR=$(dirname $0)
 JATTACH=$SCRIPT_DIR/build/jattach
 UNAME_S=$(uname -s)
 if [ "$UNAME_S" == "Darwin" ]; then
-    # jattach will make realpath call for mac os x
     PROFILER=$SCRIPT_DIR/build/libasyncProfiler.so
+    PROFILER=$(perl -MCwd -e 'print Cwd::abs_path shift' $PROFILER)
 else
     PROFILER=$(readlink -f $SCRIPT_DIR/build/libasyncProfiler.so)
 fi

--- a/src/jattach.c
+++ b/src/jattach.c
@@ -150,6 +150,17 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+#ifdef __APPLE__
+    // On macosx full path is required, but there is no readlink -f analogue
+    char* path = argv[3];
+    char real_path[PATH_MAX];
+    if (!realpath(path, real_path)) {
+        perror("Cannot canonicalize agent path");
+        return 1;
+    }
+    argv[3] = real_path;
+#endif // __APPLE__
+
     // Make write() return EPIPE instead of silent process termination
     signal(SIGPIPE, SIG_IGN);
 

--- a/src/jattach.c
+++ b/src/jattach.c
@@ -150,17 +150,6 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-#ifdef __APPLE__
-    // On macosx full path is required, but there is no readlink -f analogue
-    char* path = argv[3];
-    char real_path[PATH_MAX];
-    if (!realpath(path, real_path)) {
-        perror("Cannot canonicalize agent path");
-        return 1;
-    }
-    argv[3] = real_path;
-#endif // __APPLE__
-
     // Make write() return EPIPE instead of silent process termination
     signal(SIGPIPE, SIG_IGN);
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -395,6 +395,8 @@ bool Profiler::start(Mode mode, int interval, int frame_buffer_size) {
     _frame_buffer_index = 0;
     _frame_buffer_overflow = false;
 
+    resetSymbols();
+    VMStructs::init(jvmLibrary());
     bool success;
     if (mode == MODE_CPU) {
         success = PerfEvents::start(interval);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -395,8 +395,6 @@ bool Profiler::start(Mode mode, int interval, int frame_buffer_size) {
     _frame_buffer_index = 0;
     _frame_buffer_overflow = false;
 
-    resetSymbols();
-
     bool success;
     if (mode == MODE_CPU) {
         success = PerfEvents::start(interval);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -207,8 +207,6 @@ class Profiler {
                                              const void* address, jint length) {
         _instance.addRuntimeStub(address, length, name);
     }
-
-    friend class VM;
 };
 
 #endif // _PROFILER_H

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -207,6 +207,8 @@ class Profiler {
                                              const void* address, jint length) {
         _instance.addRuntimeStub(address, length, name);
     }
+
+    friend class VM;
 };
 
 #endif // _PROFILER_H

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -16,14 +16,127 @@
 
 #ifdef __APPLE__
 
+#include <mach-o/loader.h>
+#include <cstring>
+#include <mach-o/nlist.h>
 #include "symbols.h"
+#include <sys/mman.h>
+#include <mach-o/dyld_images.h>
+#include <fcntl.h>
 
+// Workaround for newer macosx versions: since 10.12.x _dyld_get_all_image_infos exists, but is not exported
+extern "C" const struct dyld_all_image_infos* _dyld_get_all_image_infos();
+
+class MachOParser {
+  private:
+    void* _lib_addr;
+
+    static load_command* find_command(mach_header_64* header, uint32_t command) {
+        load_command* result = (load_command*)((uint64_t)header + sizeof(mach_header_64));
+
+        if (command == 0) {
+            return result;
+        }
+
+        for (uint32_t i = 0; i < header->ncmds; i++) {
+            if (result->cmd == command) {
+                break;
+            }
+
+            result = (load_command*)((uint64_t)result + result->cmdsize);
+        }
+        return result;
+    }
+
+  public:
+    MachOParser(void* _lib_addr) : _lib_addr(_lib_addr) {
+    }
+
+    uintptr_t find_symbol_offset(const char* symbol_name) {
+        load_command* command = find_command((mach_header_64*)_lib_addr, LC_SYMTAB);
+        symtab_command* symtab = (symtab_command*)command;
+        nlist_64* symbol_table = (nlist_64*)((char*)_lib_addr + symtab->symoff);
+
+        const char* str_table = (char*)_lib_addr + symtab->stroff;
+        // Scan through whole symbol table
+        for (uint32_t sym_n = 0; sym_n < symtab->nsyms; ++sym_n) {
+            uint32_t str_offset = symbol_table[sym_n].n_un.n_strx;
+            const char* sym_name = &str_table[str_offset];
+            uintptr_t offset = symbol_table[sym_n].n_value;
+            if (strcmp(sym_name, symbol_name) == 0 && offset != 0) {
+                return offset;
+            }
+        }
+        return 0;
+    }
+};
+
+void add_symbol(MachOParser &parser, uintptr_t lib_addr, const char* symbol_name, NativeCodeCache* cc) {
+    uintptr_t offset = parser.find_symbol_offset(symbol_name);
+    cc->add((void*)(lib_addr + offset), sizeof(uintptr_t), symbol_name + 1);
+}
 
 void Symbols::parseKernelSymbols(NativeCodeCache* cc) {
 }
 
 int Symbols::parseMaps(NativeCodeCache** array, int size) {
-    return 0;
+
+    const dyld_all_image_infos* dyld_all_image_infos = _dyld_get_all_image_infos();
+    const char* lib_path = NULL;
+    uintptr_t loaded_lib_addr = 0;
+    for (int i = 0; i < dyld_all_image_infos->infoArrayCount; i++) {
+        const char* path = dyld_all_image_infos->infoArray[i].imageFilePath;
+        size_t length = strlen(path);
+        if (strcmp(path + length - 12, "libjvm.dylib") == 0) {
+            lib_path = path;
+            loaded_lib_addr = (uintptr_t)dyld_all_image_infos->infoArray[i].imageLoadAddress;
+        }
+    }
+
+    if (lib_path == NULL) {
+        return 0;
+    }
+
+    // Loaded lib has different symbol table representation, it's much easier to parse original one
+    int fd = open(lib_path, O_RDONLY);
+    if (fd == -1) {
+        return 0;
+    }
+
+    size_t length = (size_t)lseek(fd, 0, SEEK_END);
+    lseek(fd, 0, SEEK_SET);
+    void* mapped_lib_addr = mmap(NULL, length, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (mapped_lib_addr == MAP_FAILED) {
+        return 0;
+    }
+
+    uint32_t magic_number;
+    read(fd, &magic_number, sizeof(magic_number));
+    if (magic_number != MH_MAGIC_64 && magic_number != MH_CIGAM_64) {
+        munmap(mapped_lib_addr, length);
+        return 0;
+    }
+
+    MachOParser parser(mapped_lib_addr);
+
+    NativeCodeCache* cc = new NativeCodeCache(lib_path);
+    array[0] = cc;
+
+
+    // There is a lot of private symbols in libjvm, register only required ones (until native stack walking is implemented)
+    add_symbol(parser, loaded_lib_addr, "_AsyncGetCallTrace", cc);
+
+    add_symbol(parser, loaded_lib_addr, "_gHotSpotVMStructs", cc);
+    add_symbol(parser, loaded_lib_addr, "_gHotSpotVMStructEntryArrayStride", cc);
+    add_symbol(parser, loaded_lib_addr, "_gHotSpotVMStructEntryTypeNameOffset", cc);
+    add_symbol(parser, loaded_lib_addr, "_gHotSpotVMStructEntryFieldNameOffset", cc);
+    add_symbol(parser, loaded_lib_addr, "_gHotSpotVMStructEntryOffsetOffset", cc);
+
+    add_symbol(parser, loaded_lib_addr, "__ZN11AllocTracer33send_allocation_in_new_tlab_eventE11KlassHandlemm", cc);
+    add_symbol(parser, loaded_lib_addr, "__ZN11AllocTracer34send_allocation_outside_tlab_eventE11KlassHandlem", cc);
+    munmap(mapped_lib_addr, length);
+    cc->sort();
+    return 1;
 }
 
 #endif // __APPLE__

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -64,13 +64,14 @@ bool VM::init(JavaVM* vm) {
     _jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_DYNAMIC_CODE_GENERATED, NULL);
 
     PerfEvents::init();
-    VMStructs::init();
-
     _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(RTLD_DEFAULT, "AsyncGetCallTrace");
     if (_asyncGetCallTrace == NULL) {
         std::cerr << "Could not find AsyncGetCallTrace function" << std::endl;
         return false;
     }
+
+    Profiler::_instance.resetSymbols();
+    VMStructs::init(Profiler::_instance.jvmLibrary());
     return true;
 }
 

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -70,8 +70,6 @@ bool VM::init(JavaVM* vm) {
         return false;
     }
 
-    Profiler::_instance.resetSymbols();
-    VMStructs::init(Profiler::_instance.jvmLibrary());
     return true;
 }
 

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -13,31 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-#include <dlfcn.h>
-#include <string.h>
+#include <unistd.h>
+#include <iostream>
 #include "vmStructs.h"
+#include "codeCache.h"
+#include <string.h>
 
 
 int VMStructs::_klass_name_offset = -1;
 int VMStructs::_symbol_length_offset = -1;
 int VMStructs::_symbol_body_offset = -1;
 
-
-uintptr_t VMStructs::getGlobalVar(const char* name) {
-    void* addr = dlsym(RTLD_DEFAULT, name);
-    if (addr == NULL) {
-        return 0;
-    }
-    return *(uintptr_t*)addr;
-}
-
-void VMStructs::init() {
-    uintptr_t entry = getGlobalVar("gHotSpotVMStructs");
-    uintptr_t stride = getGlobalVar("gHotSpotVMStructEntryArrayStride");
-    uintptr_t type_offset = getGlobalVar("gHotSpotVMStructEntryTypeNameOffset");
-    uintptr_t field_offset = getGlobalVar("gHotSpotVMStructEntryFieldNameOffset");
-    uintptr_t offset_offset = getGlobalVar("gHotSpotVMStructEntryOffsetOffset");
+void VMStructs::init(NativeCodeCache* libjvm) {
+    uintptr_t entry = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructs"));
+    uintptr_t stride = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryArrayStride"));
+    uintptr_t type_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryTypeNameOffset"));
+    uintptr_t field_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryFieldNameOffset"));
+    uintptr_t offset_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryOffsetOffset"));
 
     if (entry == 0 || stride == 0) {
         return;

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -24,12 +24,22 @@ int VMStructs::_klass_name_offset = -1;
 int VMStructs::_symbol_length_offset = -1;
 int VMStructs::_symbol_body_offset = -1;
 
+uintptr_t dereferenceSymbol(NativeCodeCache* lib, const char* symbol_name) {
+    const void* symbol = lib->findSymbol(symbol_name);
+    if (symbol == NULL || symbol < 0) {
+        // Fallback to avoid jvm crash in case of missing symbols
+        return 0;
+    }
+
+    return *((uintptr_t*)symbol);
+}
+
 void VMStructs::init(NativeCodeCache* libjvm) {
-    uintptr_t entry = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructs"));
-    uintptr_t stride = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryArrayStride"));
-    uintptr_t type_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryTypeNameOffset"));
-    uintptr_t field_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryFieldNameOffset"));
-    uintptr_t offset_offset = *((uintptr_t*)libjvm->findSymbol("gHotSpotVMStructEntryOffsetOffset"));
+    uintptr_t entry = dereferenceSymbol(libjvm, "gHotSpotVMStructs");
+    uintptr_t stride = dereferenceSymbol(libjvm, "gHotSpotVMStructEntryArrayStride");
+    uintptr_t type_offset = dereferenceSymbol(libjvm, "gHotSpotVMStructEntryTypeNameOffset");
+    uintptr_t field_offset = dereferenceSymbol(libjvm, "gHotSpotVMStructEntryFieldNameOffset");
+    uintptr_t offset_offset = dereferenceSymbol(libjvm, "gHotSpotVMStructEntryOffsetOffset");
 
     if (entry == 0 || stride == 0) {
         return;

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -19,11 +19,9 @@
 
 #include <stdint.h>
 
+class NativeCodeCache;
 
 class VMStructs {
-  private:
-    static uintptr_t getGlobalVar(const char* name);
-
   protected:
     static int _klass_name_offset;
     static int _symbol_length_offset;
@@ -34,7 +32,7 @@ class VMStructs {
     }
 
   public:
-    static void init();
+    static void init(NativeCodeCache* libjvm);
 
     static bool available() {
         return _klass_name_offset >= 0

--- a/test/AllocatingTarget.java
+++ b/test/AllocatingTarget.java
@@ -1,0 +1,21 @@
+import java.util.concurrent.ThreadLocalRandom;
+
+
+public class AllocatingTarget {
+
+  public static volatile Object sink;
+
+  public static void main(String[] args) {
+    while (true) {
+      allocate();
+    }
+  }
+
+  private static void allocate() {
+    if (ThreadLocalRandom.current().nextBoolean()) {
+      sink = new int[128 * 1000];
+    } else {
+      sink = new Integer[128 * 1000];
+    }
+  }
+}

--- a/test/Target.java
+++ b/test/Target.java
@@ -16,8 +16,10 @@ class Target {
 
   private static void method3() throws Exception {
     for (int i = 0; i < 1000; ++i) {
-      new Scanner(new File("/proc/cpuinfo")).useDelimiter("\\Z").next();
-    }
+        for (String s : new File("/tmp").list()) {
+          value += s.hashCode();
+        }
+      }
   }
 
   public static void main(String[] args) throws Exception {

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -5,14 +5,14 @@ set -x  # print all executed lines
 
 pushd $(dirname $0)
 
-javac Target.java
-java Target &
+javac AllocatingTarget.java
+java AllocatingTarget &
 
 FILENAME=/tmp/java.trace
 JAVAPID=$!
 
 sleep 1     # allow the Java runtime to initialize
-../profiler.sh -f $FILENAME -o collapsed -d 5 $JAVAPID
+../profiler.sh -f $FILENAME -o collapsed -d 5 -m heap $JAVAPID
 
 kill $JAVAPID
 
@@ -22,8 +22,7 @@ function assert_string() {
   fi
 }
 
-assert_string "Target.main;Target.method1 "
-assert_string "Target.main;Target.method2 "
-assert_string "Target.main;Target.method3;java/io/File"
+assert_string "AllocatingTarget.main;\[Ljava/lang/Integer;"
+assert_string "AllocatingTarget.allocate;\[I "
 
 popd

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -22,7 +22,7 @@ function assert_string() {
   fi
 }
 
-assert_string "AllocatingTarget.main;\[Ljava/lang/Integer;"
-assert_string "AllocatingTarget.allocate;\[I "
+assert_string "AllocatingTarget.allocate;.*\[Ljava/lang/Integer"
+assert_string "AllocatingTarget.allocate;.*\[I"
 
 popd


### PR DESCRIPTION
Allocation profiler support is added, `profiler.sh` is fixed, `VMStructs::init` rewritten to be used both by mac os x and linux builds, new test added.

Some comments about implementation:
1) `VMStructs::init` rewrite wasn't necessary, but now the code is shared between OSes
2) `realpath` in jattach can be avoided by using some bash/perl scripting in `profiler.sh`
3) Loaded jvm is found via private API (moreover, hidden in current release), I'd appreciate if someone will test it on any version different from 10.12.5
4) Tested on both linux (CentOS 3.10.0) and mac os x (10.12.5)