### PR TITLE
Alloc details

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,13 +203,16 @@ This is a comma-separated list of the following options:
   - `summary` - dump basic profiling statistics;
   - `traces[=N]` - dump call traces (at most N samples);
   - `flat[=N]` - dump flat profile (top N hot methods);
-  - `collapsed` - dump collapsed call traces in the format used by
+  - `collapsed[=C]` - dump collapsed call traces in the format used by
   [FlameGraph](https://github.com/brendangregg/FlameGraph) script. This is
   a collection of call stacks, where each line is a semicolon separated list
-  of frames followed by the sample count. For example:
+  of frames followed by a counter. For example:
   ```
   java/lang/Thread.run;Primes$1.run;Primes.access$000;Primes.primesThread;Primes.isPrime 1056
   ```
+  - `collapsed=samples` - the counter is a number of samples for the given trace;  
+  - `collaped=total` - the counter is a total value of collected metric, e.g. total allocation size.
+  
   The default format is `summary,traces=200,flat=200`.
 
 * `-f FILENAME` - the file name to dump the profile information to.  

--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -69,24 +69,18 @@ void AllocTracer::installSignalHandler() {
 // Called whenever our breakpoint trap is hit
 void AllocTracer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     StackFrame frame(ucontext);
-    VMKlass* alloc_class;
-    u64 obj_size;
 
     // PC points either to BREAKPOINT instruction or to the next one
     if (frame.pc() - (uintptr_t)_in_new_tlab._entry <= sizeof(instruction_t)) {
         // send_allocation_in_new_tlab_event(KlassHandle klass, size_t tlab_size, size_t alloc_size)
-        alloc_class = (VMKlass*)frame.arg0();
-        obj_size = frame.arg2();
+        Profiler::_instance.recordSample(ucontext, frame.arg2(), BCI_ALLOC_NEW, (jmethodID)frame.arg0());
     } else if (frame.pc() - (uintptr_t)_outside_tlab._entry <= sizeof(instruction_t)) {
         // send_allocation_outside_tlab_event(KlassHandle klass, size_t alloc_size);
-        alloc_class = (VMKlass*)frame.arg0();
-        obj_size = frame.arg1();
+        Profiler::_instance.recordSample(ucontext, frame.arg1(), BCI_ALLOC_OUT, (jmethodID)frame.arg0());
     } else {
         // Not our trap; nothing to do
         return;
     }
-
-    Profiler::_instance.recordSample(ucontext, obj_size, alloc_class);
 
     // Leave the trapped function by simulating "ret" instruction
     frame.ret();

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -29,7 +29,9 @@
 //     status        - print profiling status (inactive / running for X seconds)
 //     cpu           - profile CPU (default)
 //     heap          - profile heap allocations
-//     collapsed     - dump collapsed stacks (the format used by FlameGraph script)
+//     collapsed[=C] - dump collapsed stacks (the format used by FlameGraph script)
+//                     C is counter type: 'samples' or 'total'
+//     folded[=C]    - synonym for collapsed
 //     summary       - dump profiling summary (number of collected samples of each type)
 //     traces[=N]    - dump top N call traces
 //     flat[=N]      - dump top N methods (aka flat profile)
@@ -59,9 +61,10 @@ const char* Arguments::parse(char* args) {
             _mode = MODE_CPU;
         } else if (strcmp(arg, "heap") == 0) {
             _mode = MODE_HEAP;
-        } else if (strcmp(arg, "collapsed") == 0) {
+        } else if (strcmp(arg, "collapsed") == 0 || strcmp(arg, "folded") == 0) {
             _action = ACTION_DUMP;
             _dump_collapsed = true;
+            _counter = value == NULL || strcmp(value, "samples") == 0 ? COUNTER_SAMPLES : COUNTER_TOTAL;
         } else if (strcmp(arg, "summary") == 0) {
             _action = ACTION_DUMP;
             _dump_summary = true;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -35,6 +35,11 @@ enum Mode {
     MODE_HEAP
 };
 
+enum Counter {
+    COUNTER_SAMPLES,
+    COUNTER_TOTAL
+};
+
 class Arguments {
   private:
     char _buf[1024];
@@ -45,6 +50,7 @@ class Arguments {
   public:
     Action _action;
     Mode _mode;
+    Counter _counter;
     int _interval;
     int _framebuf;
     char* _file;
@@ -56,6 +62,7 @@ class Arguments {
     Arguments(char* args) :
         _action(ACTION_NONE),
         _mode(MODE_CPU),
+        _counter(COUNTER_SAMPLES),
         _interval(DEFAULT_INTERVAL),
         _framebuf(DEFAULT_FRAMEBUF),
         _file(NULL),

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -82,14 +82,18 @@ char* FrameName::javaClassName(const char* symbol, int length, bool dotted) {
 FrameName::FrameName(ASGCT_CallFrame& frame, bool dotted) {
     if (frame.method_id == NULL) {
         _str = "[unknown]";
+    
     } else if (frame.bci == BCI_NATIVE_FRAME) {
         _str = cppDemangle((const char*)frame.method_id);
+
     } else if (frame.bci == BCI_ALLOC_NEW_TLAB) {
         VMKlass* alloc_class = (VMKlass*)frame.method_id;
-        _str = strcat(javaClassName(alloc_class), "_[i]");
+        _str = strcat(javaClassName(alloc_class), dotted ? " (new)" : "_[i]");
+
     } else if (frame.bci == BCI_ALLOC_OUTSIDE_TLAB) {
         VMKlass* alloc_class = (VMKlass*)((uintptr_t)frame.method_id ^ 1);
-        _str = strcat(javaClassName(alloc_class), "_[k]");
+        _str = strcat(javaClassName(alloc_class), dotted ? " (out)" : "_[k]");
+
     } else {
         jclass method_class;
         char* class_name = NULL;

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -15,6 +15,8 @@
  */
 
 #include <cxxabi.h>
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 #include "frameName.h"
 
@@ -32,15 +34,23 @@ const char* FrameName::cppDemangle(const char* name) {
     return name;
 }
 
-const char* FrameName::javaClassName(const char* symbol, int length, bool dotted) {
-    const char* s = symbol;
-    while (*s == '[') {
-        s++;
+char* FrameName::javaClassName(VMKlass* klass) {
+    VMSymbol* symbol = klass->name();
+    return javaClassName(symbol->body(), symbol->length(), true);
+}
+
+char* FrameName::javaClassName(const char* symbol, int length, bool dotted) {
+    int array_dimension = 0;
+    while (*symbol == '[') {
+        array_dimension++;
+        symbol++;
     }
 
-    int array_dimension = s - symbol;
-    if (array_dimension != 0) {
-        switch (*s) {
+    if (array_dimension == 0) {
+        strncpy(_buf, symbol, length);
+        _buf[length] = 0;
+    } else {
+        switch (*symbol) {
             case 'B': strcpy(_buf, "byte");    break;
             case 'C': strcpy(_buf, "char");    break;
             case 'I': strcpy(_buf, "int");     break;
@@ -49,16 +59,19 @@ const char* FrameName::javaClassName(const char* symbol, int length, bool dotted
             case 'Z': strcpy(_buf, "boolean"); break;
             case 'F': strcpy(_buf, "float");   break;
             case 'D': strcpy(_buf, "double");  break;
-            case 'L': strncpy(_buf, s + 1, length -= array_dimension -= 2); _buf[break;
+            default:
+                length -= array_dimension + 2;
+                strncpy(_buf, symbol + 1, length);
+                _buf[length] = 0;
         }
-    }
 
-    while (array_dimension-- > 0) {
-        strcat(_buf, "[]");
+        do {
+            strcat(_buf, "[]");
+        } while (--array_dimension > 0);
     }
 
     if (dotted) {
-        for (char* s = name; *s; s++) {
+        for (char* s = _buf; *s; s++) {
             if (*s == '/') *s = '.';
         }
     }
@@ -67,36 +80,38 @@ const char* FrameName::javaClassName(const char* symbol, int length, bool dotted
 }
 
 FrameName::FrameName(ASGCT_CallFrame& frame, bool dotted) {
-        if (frame.method_id == NULL) {
-            _str = "[unknown]";
-        } else if (frame.bci == BCI_NATIVE_FRAME) {
-            _str = cppDemangle((const char*)frame.method_id);
-        } else if (frame.bci == BCI_ALLOC_NEW || frame.bci == BCI_ALLOC_OUT) {
-            VMSymbol* symbol = (VMSymbol*)frame.method_id;
-            _str = javaClassName(symbol->body(), symbol->length());
+    if (frame.method_id == NULL) {
+        _str = "[unknown]";
+    } else if (frame.bci == BCI_NATIVE_FRAME) {
+        _str = cppDemangle((const char*)frame.method_id);
+    } else if (frame.bci == BCI_ALLOC_NEW_TLAB) {
+        VMKlass* alloc_class = (VMKlass*)frame.method_id;
+        _str = strcat(javaClassName(alloc_class), "_[i]");
+    } else if (frame.bci == BCI_ALLOC_OUTSIDE_TLAB) {
+        VMKlass* alloc_class = (VMKlass*)((uintptr_t)frame.method_id ^ 1);
+        _str = strcat(javaClassName(alloc_class), "_[k]");
+    } else {
+        jclass method_class;
+        char* class_name = NULL;
+        char* method_name = NULL;
+
+        jvmtiEnv* jvmti = VM::jvmti();
+        jvmtiError err;
+
+        if ((err = jvmti->GetMethodName(frame.method_id, &method_name, NULL, NULL)) == 0 &&
+            (err = jvmti->GetMethodDeclaringClass(frame.method_id, &method_class)) == 0 &&
+            (err = jvmti->GetClassSignature(method_class, &class_name, NULL)) == 0) {
+            // Trim 'L' and ';' off the class descriptor like 'Ljava/lang/Object;'
+            char* s = javaClassName(class_name + 1, strlen(class_name) - 2, dotted);
+            strcat(s, ".");
+            strcat(s, method_name);
+            _str = s;
         } else {
-            jclass method_class;
-            char* class_name = NULL;
-            char* method_name = NULL;
-
-            jvmtiEnv* jvmti = VM::jvmti();
-            jvmtiError err;
-
-            if ((err = jvmti->GetMethodName(frame.method_id, &method_name, NULL, NULL)) == 0 &&
-                (err = jvmti->GetMethodDeclaringClass(frame.method_id, &method_class)) == 0 &&
-                (err = jvmti->GetClassSignature(method_class, &class_name, NULL)) == 0) {
-                snprintf(_buf, sizeof(_buf), "%s.%s", fixClassName(class_name, dotted), method_name);
-            } else {
-                snprintf(_buf, sizeof(_buf), "[jvmtiError %d]", err);
-            }
+            snprintf(_buf, sizeof(_buf), "[jvmtiError %d]", err);
             _str = _buf;
-
-            jvmti->Deallocate((unsigned char*)class_name);
-            jvmti->Deallocate((unsigned char*)method_name);
         }
-    }
 
-    const char* toString() {
-        return _str;
+        jvmti->Deallocate((unsigned char*)class_name);
+        jvmti->Deallocate((unsigned char*)method_name);
     }
-};
+}

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2017 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cxxabi.h>
+#include <string.h>
+#include "frameName.h"
+
+
+const char* FrameName::cppDemangle(const char* name) {
+    if (name != NULL && name[0] == '_' && name[1] == 'Z') {
+        int status;
+        char* demangled = abi::__cxa_demangle(name, NULL, NULL, &status);
+        if (demangled != NULL) {
+            strncpy(_buf, demangled, sizeof(_buf));
+            free(demangled);
+            return _buf;
+        }
+    }
+    return name;
+}
+
+const char* FrameName::javaClassName(const char* symbol, int length, bool dotted) {
+    const char* s = symbol;
+    while (*s == '[') {
+        s++;
+    }
+
+    int array_dimension = s - symbol;
+    if (array_dimension != 0) {
+        switch (*s++) {
+            case 'B': strcpy(_buf, "byte");    break;
+            case 'C': strcpy(_buf, "char");    break;
+            case 'I': strcpy(_buf, "int");     break;
+            case 'J': strcpy(_buf, "long");    break;
+            case 'S': strcpy(_buf, "short");   break;
+            case 'Z': strcpy(_buf, "boolean"); break;
+            case 'F': strcpy(_buf, "float");   break;
+            case 'D': strcpy(_buf, "double");  break;
+            case 'L': _buf[0] = 0; length--;   break;
+        }
+        length -= arr + 1;
+    }
+     
+     
+     && *symbol == 'L') {
+        symbol++;
+        length--;
+    }
+
+
+
+    if (arr
+
+
+        if (dotted) {
+            for (char* s = name; *s; s++) {
+                if (*s == '/') *s = '.';
+            }
+        }
+
+        // Class signature is a string of form 'Ljava/lang/Thread;'
+        // So we have to remove the first 'L' and the last ';'
+        name[strlen(name) - 1] = 0;
+        return name + 1;
+    }
+}
+
+FrameName::FrameName(ASGCT_CallFrame& frame, bool dotted) {
+        if (frame.method_id == NULL) {
+            _str = "[unknown]";
+        } else if (frame.bci == BCI_NATIVE_FRAME) {
+            _str = demangle((const char*)frame.method_id);
+        } else if (frame.bci == BCI_ALLOC_NEW || frame.bci == BCI_ALLOC_OUT) {
+            _str = symbolName((VMSymbol*)frame.method_id);
+        } else {
+            jclass method_class;
+            char* class_name = NULL;
+            char* method_name = NULL;
+
+            jvmtiEnv* jvmti = VM::jvmti();
+            jvmtiError err;
+
+            if ((err = jvmti->GetMethodName(frame.method_id, &method_name, NULL, NULL)) == 0 &&
+                (err = jvmti->GetMethodDeclaringClass(frame.method_id, &method_class)) == 0 &&
+                (err = jvmti->GetClassSignature(method_class, &class_name, NULL)) == 0) {
+                snprintf(_buf, sizeof(_buf), "%s.%s", fixClassName(class_name, dotted), method_name);
+            } else {
+                snprintf(_buf, sizeof(_buf), "[jvmtiError %d]", err);
+            }
+            _str = _buf;
+
+            jvmti->Deallocate((unsigned char*)class_name);
+            jvmti->Deallocate((unsigned char*)method_name);
+        }
+    }
+
+    const char* toString() {
+        return _str;
+    }
+};

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -18,6 +18,7 @@
 #define _FRAMENAME_H
 
 #include "vmEntry.h"
+#include "vmStructs.h"
 
 
 class FrameName {
@@ -26,7 +27,8 @@ class FrameName {
     const char* _str;
 
     const char* cppDemangle(const char* name);
-    const char* javaClassName(const char* symbol, int length);
+    char* javaClassName(VMKlass* klass);
+    char* javaClassName(const char* symbol, int length, bool dotted);
 
   public:
     FrameName(ASGCT_CallFrame& frame, bool dotted = false);

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _FRAMENAME_H
+#define _FRAMENAME_H
+
+#include "vmEntry.h"
+
+
+class FrameName {
+  private:
+    char _buf[520];
+    const char* _str;
+
+    const char* cppDemangle(const char* name);
+    const char* javaClassName(const char* symbol, int length);
+
+  public:
+    FrameName(ASGCT_CallFrame& frame, bool dotted = false);
+
+    const char* toString() {
+        return _str;
+    }
+};
+
+#endif // _FRAMENAME_H

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -36,9 +36,9 @@ Java_one_profiler_AsyncProfiler_getSamples(JNIEnv* env, jobject unused) {
 }
 
 extern "C" JNIEXPORT jstring JNICALL
-Java_one_profiler_AsyncProfiler_dumpCollapsed0(JNIEnv* env, jobject unused) {
+Java_one_profiler_AsyncProfiler_dumpCollapsed0(JNIEnv* env, jobject unused, jint counter) {
     std::ostringstream out;
-    Profiler::_instance.dumpCollapsed(out);
+    Profiler::_instance.dumpCollapsed(out, counter == COUNTER_SAMPLES ? COUNTER_SAMPLES : COUNTER_TOTAL);
     return env->NewStringUTF(out.str().c_str());
 }
 

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -32,7 +32,7 @@ Java_one_profiler_AsyncProfiler_stop0(JNIEnv* env, jobject unused) {
 
 extern "C" JNIEXPORT jint JNICALL
 Java_one_profiler_AsyncProfiler_getSamples(JNIEnv* env, jobject unused) {
-    return (jint)Profiler::_instance.samples();
+    return (jint)Profiler::_instance.total_samples();
 }
 
 extern "C" JNIEXPORT jstring JNICALL

--- a/src/perfEvent.cpp
+++ b/src/perfEvent.cpp
@@ -153,7 +153,7 @@ void PerfEvents::installSignalHandler() {
 }
 
 void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-    Profiler::_instance.recordSample(ucontext, 1, NULL);
+    Profiler::_instance.recordSample(ucontext, 1, 0, NULL);
     ioctl(siginfo->si_fd, PERF_EVENT_IOC_REFRESH, 1);
 }
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -193,6 +193,7 @@ void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     }
 
     Profiler::_instance.recordSample(ucontext, counter, 0, NULL);
+    ioctl(siginfo->si_fd, PERF_EVENT_IOC_RESET, 0);
     ioctl(siginfo->si_fd, PERF_EVENT_IOC_REFRESH, 1);
 }
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -187,7 +187,12 @@ void PerfEvents::installSignalHandler() {
 }
 
 void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-    Profiler::_instance.recordSample(ucontext, 1, 0, NULL);
+    u64 counter;
+    if (read(siginfo->si_fd, &counter, sizeof(counter)) != sizeof(counter)) {
+        counter = 1;
+    }
+
+    Profiler::_instance.recordSample(ucontext, counter, 0, NULL);
     ioctl(siginfo->si_fd, PERF_EVENT_IOC_REFRESH, 1);
 }
 

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -47,7 +47,7 @@ void PerfEvents::installSignalHandler() {
 }
 
 void PerfEvents::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-    Profiler::_instance.recordSample(ucontext, 1, NULL);
+    Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
 }
 
 bool PerfEvents::start(int interval) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -325,7 +325,7 @@ bool Profiler::start(Mode mode, int interval, int frame_buffer_size) {
     _frame_buffer_overflow = false;
 
     resetSymbols();
-    VMStructs::init(jvmLibrary());
+
     bool success;
     if (mode == MODE_CPU) {
         success = PerfEvents::start(interval);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -400,19 +400,19 @@ void Profiler::dumpSummary(std::ostream& out) {
  * 
  * <frame>;<frame>;...;<topmost frame> <count>
  */
-void Profiler::dumpCollapsed(std::ostream& out) {
+void Profiler::dumpCollapsed(std::ostream& out, Counter counter) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
     for (int i = 0; i < MAX_CALLTRACES; i++) {
         CallTraceSample& trace = _traces[i];
         if (trace._samples == 0) continue;
-        
+
         for (int j = trace._num_frames - 1; j >= 0; j--) {
             FrameName fn(_frame_buffer[trace._start_frame + j]);
             out << fn.toString() << (j == 0 ? ' ' : ';');
         }
-        out << trace._samples << "\n";
+        out << (counter == COUNTER_SAMPLES ? trace._samples : trace._counter) << "\n";
     }
 }
 
@@ -491,7 +491,7 @@ void Profiler::runInternal(Arguments& args, std::ostream& out) {
         }
         case ACTION_DUMP:
             stop();
-            if (args._dump_collapsed) dumpCollapsed(out);
+            if (args._dump_collapsed) dumpCollapsed(out, args._counter);
             if (args._dump_summary) dumpSummary(out);
             if (args._dump_traces > 0) dumpTraces(out, args._dump_traces);
             if (args._dump_flat > 0) dumpFlat(out, args._dump_flat);

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -406,13 +406,13 @@ void Profiler::dumpCollapsed(std::ostream& out) {
 
     for (int i = 0; i < MAX_CALLTRACES; i++) {
         CallTraceSample& trace = _traces[i];
-        if (trace._counter == 0) continue;
+        if (trace._samples == 0) continue;
         
         for (int j = trace._num_frames - 1; j >= 0; j--) {
             FrameName fn(_frame_buffer[trace._start_frame + j]);
             out << fn.toString() << (j == 0 ? ' ' : ';');
         }
-        out << trace._counter << "\n";
+        out << trace._samples << "\n";
     }
 }
 
@@ -428,10 +428,10 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
 
     for (int i = 0; i < max_traces; i++) {
         CallTraceSample& trace = _traces[i];
-        if (trace._counter == 0) break;
+        if (trace._samples == 0) break;
 
-        snprintf(buf, sizeof(buf), "Samples: %lld, Counter: %lld (%.2f%%)\n",
-                 trace._samples, trace._counter, trace._counter * percent);
+        snprintf(buf, sizeof(buf), "Total: %lld (%.2f%%)  samples: %lld\n",
+                 trace._counter, trace._counter * percent, trace._samples);
         out << buf;
 
         for (int j = 0; j < trace._num_frames; j++) {
@@ -454,11 +454,12 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
     if (max_methods > MAX_CALLTRACES) max_methods = MAX_CALLTRACES;
 
     for (int i = 0; i < max_methods; i++) {
-        u64 counter = _methods[i]._counter;
-        if (counter == 0) break;
+        MethodSample& method = _methods[i];
+        if (method._samples == 0) break;
 
-        FrameName fn(_methods[i]._method, true);
-        snprintf(buf, sizeof(buf), "%10lld (%.2f%%) %s\n", counter, counter * percent, fn.toString());
+        FrameName fn(method._method, true);
+        snprintf(buf, sizeof(buf), "%12lld (%5.2f%%)  %6lld  %s\n",
+                 method._counter, method._counter * percent, method._samples, fn.toString());
         out << buf;
     }
 }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -186,7 +186,7 @@ class Profiler {
     bool start(Mode mode, int interval, int frame_buffer_size);
     bool stop();
     void dumpSummary(std::ostream& out);
-    void dumpCollapsed(std::ostream& out);
+    void dumpCollapsed(std::ostream& out, Counter counter);
     void dumpTraces(std::ostream& out, int max_traces);
     void dumpFlat(std::ostream& out, int max_methods);
     void recordSample(void* ucontext, u64 counter, jint event_type, jmethodID event);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -24,13 +24,12 @@
 #include "spinLock.h"
 #include "codeCache.h"
 #include "vmEntry.h"
-#include "vmStructs.h"
 
 
-const int MAX_CALLTRACES    = 32768;
-const int MAX_STACK_FRAMES  = 4096;
+const int MAX_CALLTRACES    = 65536;
+const int MAX_STACK_FRAMES  = 2048;
 const int MAX_NATIVE_FRAMES = 128;
-const int MAX_NATIVE_LIBS   = 4096;
+const int MAX_NATIVE_LIBS   = 2048;
 const int CONCURRENCY_LEVEL = 16;
 
 typedef unsigned long long u64;
@@ -40,8 +39,15 @@ static inline int cmp64(u64 a, u64 b) {
 }
 
 
+union CallTraceBuffer {
+    ASGCT_CallFrame _asgct_frames[MAX_STACK_FRAMES];
+    jvmtiFrameInfo _jvmti_frames[MAX_STACK_FRAMES];
+};
+
+
 class CallTraceSample {
   private:
+    u64 _samples;
     u64 _counter;
     int _start_frame; // Offset in frame buffer
     int _num_frames;
@@ -56,6 +62,7 @@ class CallTraceSample {
 
 class MethodSample {
   private:
+    u64 _samples;
     u64 _counter;
     ASGCT_CallFrame _method;
 
@@ -114,7 +121,7 @@ class Profiler {
     Mode _mode;
     time_t _start_time;
 
-    u64 _samples;
+    u64 _total_samples;
     u64 _total_counter;
     u64 _failures[FAILURE_TYPES];
     u64 _hashes[MAX_CALLTRACES];
@@ -122,7 +129,7 @@ class Profiler {
     MethodSample _methods[MAX_CALLTRACES];
 
     SpinLock _locks[CONCURRENCY_LEVEL];
-    ASGCT_CallFrame _asgct_buffer[CONCURRENCY_LEVEL][MAX_STACK_FRAMES];
+    CallTraceBuffer _calltrace_buffer[CONCURRENCY_LEVEL];
     ASGCT_CallFrame* _frame_buffer;
     int _frame_buffer_size;
     volatile int _frame_buffer_index;
@@ -144,7 +151,7 @@ class Profiler {
     const char* findNativeMethod(const void* address);
     int getNativeTrace(void* ucontext, ASGCT_CallFrame* frames);
     int getJavaTrace(void* ucontext, ASGCT_CallFrame* frames, int max_depth);
-    int makeAllocationFrame(VMKlass* alloc_class, ASGCT_CallFrame* frames);
+    int makeEventFrame(ASGCT_CallFrame* frames, jint event_type, jmethodID event);
     bool fillTopFrame(const void* pc, ASGCT_CallFrame* frame);
     u64 hashCallTrace(int num_frames, ASGCT_CallFrame* frames);
     void storeCallTrace(int num_frames, ASGCT_CallFrame* frames, u64 counter);
@@ -170,7 +177,7 @@ class Profiler {
         pthread_mutex_init(&_state_lock, NULL);
     }
 
-    u64 samples()       { return _samples; }
+    u64 total_samples() { return _total_samples; }
     u64 total_counter() { return _total_counter; }
     const char* mode()  { return _mode == MODE_CPU ? "CPU" : "HEAP"; }
     time_t uptime()     { return time(NULL) - _start_time; }
@@ -182,7 +189,7 @@ class Profiler {
     void dumpCollapsed(std::ostream& out);
     void dumpTraces(std::ostream& out, int max_traces);
     void dumpFlat(std::ostream& out, int max_methods);
-    void recordSample(void* ucontext, u64 counter, VMKlass* alloc_class);
+    void recordSample(void* ucontext, u64 counter, jint event_type, jmethodID event);
     NativeCodeCache* jvmLibrary();
 
     static void JNICALL VMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -22,9 +22,9 @@
 
 // Denotes ASGCT_CallFrame where method_id has special meaning (not jmethodID)
 enum ASGCT_CallFrameType {
-    BCI_NATIVE_FRAME = -10, // method_id is native function name (char*)
-    BCI_ALLOC_NEW    = -11, // method_id is Klass descriptor (VMSymbol*)
-    BCI_ALLOC_OUT    = -12, // method_id is Klass descriptor (VMSymbol*)
+    BCI_NATIVE_FRAME = -10,       // method_id is native function name (char*)
+    BCI_ALLOC_NEW_TLAB = -11,     // method_id is Klass descriptor (VMSymbol*)
+    BCI_ALLOC_OUTSIDE_TLAB = -12, // method_id is Klass descriptor (VMSymbol*)
 };
 
 typedef struct {

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -23,7 +23,8 @@
 // Denotes ASGCT_CallFrame where method_id has special meaning (not jmethodID)
 enum ASGCT_CallFrameType {
     BCI_NATIVE_FRAME = -10, // method_id is native function name (char*)
-    BCI_SYMBOL       = -11, // method_id is Klass descriptor (VMSymbol*)
+    BCI_ALLOC_NEW    = -11, // method_id is Klass descriptor (VMSymbol*)
+    BCI_ALLOC_OUT    = -12, // method_id is Klass descriptor (VMSymbol*)
 };
 
 typedef struct {

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -32,6 +32,6 @@ fi
     fi
   }
 
-  assert_string "AllocatingTarget.allocate;.*\[Ljava/lang/Integer"
-  assert_string "AllocatingTarget.allocate;.*\[I"
+  assert_string "AllocatingTarget.allocate;.*java.lang.Integer\[\]"
+  assert_string "AllocatingTarget.allocate;.*int\[\]"
 )


### PR DESCRIPTION
- Collect counter values in addition to number of samples.
- Added option to output either counter total value or number of samples in collapsed format. In particular, heap profiles can now display either object count or their total size.
- Distinguish between allocations in new TLAB vs. allocations outside TLAB. They are displayed in different color in flame graph.
- Pretty class names in allocation profile, e.g. `java.lang.Integer[]` instead of `[Ljava/lang/Integer;`

Resolves #46 