### PR TITLE
Load AsyncGetCallTrace from libjvm.so

### DIFF
--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -70,6 +70,14 @@ void VM::init(JavaVM* vm, bool attach) {
     PerfEvents::init();
 
     _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(RTLD_DEFAULT, "AsyncGetCallTrace");
+    if (_asyncGetCallTrace == NULL) {
+        void* libjvm_handle = dlopen("libjvm.so", RTLD_NOW);
+        if (!libjvm_handle) {
+            std::cerr << "Failed to load libjvm.so: " << dlerror() << std::endl;
+        }
+	// try loading AsyncGetCallTrace after opening libjvm.so
+        _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(libjvm_handle, "AsyncGetCallTrace");
+    }
 
     if (attach) {
         loadAllMethodIDs(_jvmti);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -71,11 +71,13 @@ void VM::init(JavaVM* vm, bool attach) {
 
     _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(RTLD_DEFAULT, "AsyncGetCallTrace");
     if (_asyncGetCallTrace == NULL) {
+	// Unable to locate AsyncGetCallTrace, it is likely that JVM has been started
+	// by JNI_CreateJavaVM() via dynamically loaded libjvm.so from a C/C++ program
         void* libjvm_handle = dlopen("libjvm.so", RTLD_NOW);
         if (!libjvm_handle) {
             std::cerr << "Failed to load libjvm.so: " << dlerror() << std::endl;
         }
-	// try loading AsyncGetCallTrace after opening libjvm.so
+	// Try loading AGCT after opening libjvm.so
         _asyncGetCallTrace = (AsyncGetCallTrace)dlsym(libjvm_handle, "AsyncGetCallTrace");
     }
 


### PR DESCRIPTION
Attempting to use async-profiler on Java code that has been launched by C++ code which dynamically loads libjvm.so and then starts embedded JVM via [JNI_CreateJavaVM()](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/invocation.html) results in:

> Could not find AsyncGetCallTrace function

That is because current attempt to load this function is only via RTLD_DEFAULT. In case of failure, we can try loading AsyncGetCallTrace from libjvm.so explicitly to handle this edge case.