### PR TITLE
#65: Add '-t' option to split profile by threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,10 @@ method ids that should fit in the buffer. If you receive messages about an
 insufficient frame buffer size, increase this value from the default.  
 Example: `./profiler.sh -b 5000000 8983`
 
+* `-t` - profile threads separately. Each stack trace will end with a frame
+that denotes a single thread.
+Example: `./profiler.sh -t 8983`
+
 * `-o fmt[,fmt...]` - specifies what information to dump when profiling ends.
 This is a comma-separated list of the following options:
   - `summary` - dump basic profiling statistics;

--- a/profiler.sh
+++ b/profiler.sh
@@ -15,6 +15,7 @@ usage() {
     echo "  -f filename       dump output to <filename>"
     echo "  -i interval       sampling interval in nanoseconds"
     echo "  -b bufsize        frame buffer size"
+    echo "  -t                profile different threads separately"
     echo "  -o fmt[,fmt...]   output format: summary|traces|flat|collapsed"
     echo ""
     echo "<pid> is a numeric process ID of the target JVM"
@@ -74,6 +75,7 @@ FILE=""
 USE_TMP="true"
 INTERVAL=""
 FRAMEBUF=""
+THREADS=""
 OUTPUT="summary,traces=200,flat=200"
 
 while [[ $# -gt 0 ]]; do
@@ -105,6 +107,9 @@ while [[ $# -gt 0 ]]; do
             FRAMEBUF=",framebuf=$2"
             shift
             ;;
+        -t)
+            THREADS=",threads"
+            ;;
         -o)
             OUTPUT="$2"
             shift
@@ -134,7 +139,7 @@ fi
 
 case $ACTION in
     start)
-        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF
+        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS
         ;;
     stop)
         jattach stop,file=$FILE,$OUTPUT
@@ -146,7 +151,7 @@ case $ACTION in
         jattach list,file=$FILE
         ;;
     collect)
-        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF
+        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS
         sleep $DURATION
         jattach stop,file=$FILE,$OUTPUT
         ;;

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -41,6 +41,7 @@ const Error Error::OK(NULL);
 //     flat[=N]      - dump top N methods (aka flat profile)
 //     interval=N    - sampling interval in ns (default: 1'000'000, i.e. 1 ms)
 //     framebuf=N    - size of the buffer for stack frames (default: 1'000'000)
+//     threads       - profile different threads separately
 //     file=FILENAME - output file name for dumping
 //
 // It is possible to specify multiple dump options at the same time
@@ -89,6 +90,8 @@ Error Arguments::parse(char* args) {
             if (value == NULL || (_framebuf = atoi(value)) <= 0) {
                 return Error("framebuf must be > 0");
             }
+        } else if (strcmp(arg, "threads") == 0) {
+            _threads = true;
         } else if (strcmp(arg, "file") == 0) {
             if (value == NULL || value[0] == 0) {
                 return Error("file must not be empty");

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -78,6 +78,7 @@ class Arguments {
     const char* _event;
     long _interval;
     int _framebuf;
+    bool _threads;
     char* _file;
     bool _dump_collapsed;
     bool _dump_summary;
@@ -90,6 +91,7 @@ class Arguments {
         _event(EVENT_CPU),
         _interval(0),
         _framebuf(DEFAULT_FRAMEBUF),
+        _threads(false),
         _file(NULL),
         _dump_collapsed(false),
         _dump_summary(false),

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -94,6 +94,10 @@ FrameName::FrameName(ASGCT_CallFrame& frame, bool dotted) {
         VMKlass* alloc_class = (VMKlass*)((uintptr_t)frame.method_id ^ 1);
         _str = strcat(javaClassName(alloc_class), dotted ? " (out)" : "_[k]");
 
+    } else if (frame.bci == BCI_THREAD_ID) {
+        snprintf(_buf, sizeof(_buf), "[thread %d]", (int)(uintptr_t)frame.method_id);
+        _str = _buf;
+
     } else {
         jclass method_class;
         char* class_name = NULL;

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -17,25 +17,42 @@
 #ifndef _FRAMENAME_H
 #define _FRAMENAME_H
 
+#include <jvmti.h>
 #include "vmEntry.h"
 #include "vmStructs.h"
+
+
+class ThreadId {
+  private:
+    int _id;
+    const char* _name;
+
+  public:
+    static int comparator(const void* t1, const void* t2) {
+        return ((ThreadId*)t1)->_id - ((ThreadId*)t2)->_id;
+    }
+
+    friend class FrameName;
+};
 
 
 class FrameName {
   private:
     char _buf[520];
-    const char* _str;
+    bool _dotted;
+    int _thread_count;
+    ThreadId* _threads;
 
+    const char* findThreadName(int tid);
     const char* cppDemangle(const char* name);
     char* javaClassName(VMKlass* klass);
     char* javaClassName(const char* symbol, int length, bool dotted);
 
   public:
-    FrameName(ASGCT_CallFrame& frame, bool dotted = false);
+    FrameName(bool dotted = false);
+    ~FrameName();
 
-    const char* toString() {
-        return _str;
-    }
+    const char* name(ASGCT_CallFrame& frame);
 };
 
 #endif // _FRAMENAME_H

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -30,7 +30,7 @@ static void throw_illegal_state(JNIEnv* env, const char* message) {
 extern "C" JNIEXPORT void JNICALL
 Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jstring event, jlong interval) {
     const char* event_str = env->GetStringUTFChars(event, NULL);
-    Error error = Profiler::_instance.start(event_str, interval, DEFAULT_FRAMEBUF);
+    Error error = Profiler::_instance.start(event_str, interval, DEFAULT_FRAMEBUF, false);
     env->ReleaseStringUTFChars(event, event_str);
 
     if (error) {

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -32,7 +32,6 @@ class PerfEvents : public Engine {
     static PerfEventType* _event_type;
     static long _interval;
 
-    static int tid();
     static void createForThread(int tid);
     static void createForAllThreads();
     static void destroyForThread(int tid);
@@ -49,8 +48,9 @@ class PerfEvents : public Engine {
     void stop();
 
     static void init();
+    static int tid();
     static const char** getAvailableEvents();
-    static int getCallChain(const void** callchain, int max_depth);
+    static int getCallChain(int tid, const void** callchain, int max_depth);
 
     static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         createForThread(tid());

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -318,8 +318,8 @@ const char** PerfEvents::getAvailableEvents() {
     return available_events;
 }
 
-int PerfEvents::getCallChain(const void** callchain, int max_depth) {
-    PerfEvent* event = &_events[tid()];
+int PerfEvents::getCallChain(int tid, const void** callchain, int max_depth) {
+    PerfEvent* event = &_events[tid];
     if (!event->tryLock()) {
         return 0;  // the event is being destroyed
     }

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -18,6 +18,7 @@
 
 #include <string.h>
 #include <sys/time.h>
+#include <pthread.h>
 #include "perfEvents.h"
 #include "profiler.h"
 
@@ -30,7 +31,9 @@ long PerfEvents::_interval;
 
 void PerfEvents::init() {}
 
-int PerfEvents::tid() { return 0; }
+int PerfEvents::tid() {
+    return pthread_mach_thread_np(pthread_self());
+}
 
 void PerfEvents::createForThread(int tid)  {}
 void PerfEvents::createForAllThreads()     {}
@@ -84,7 +87,7 @@ const char** PerfEvents::getAvailableEvents() {
     return available_events;
 }
 
-int PerfEvents::getCallChain(const void** callchain, int max_depth) {
+int PerfEvents::getCallChain(int tid, const void** callchain, int max_depth) {
     return 0;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -440,6 +440,7 @@ void Profiler::dumpCollapsed(std::ostream& out, Counter counter) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
+    FrameName fn;
     u64 unknown = 0;
 
     for (int i = 0; i < MAX_CALLTRACES; i++) {
@@ -452,8 +453,8 @@ void Profiler::dumpCollapsed(std::ostream& out, Counter counter) {
         }
 
         for (int j = trace._num_frames - 1; j >= 0; j--) {
-            FrameName fn(_frame_buffer[trace._start_frame + j]);
-            out << fn.toString() << (j == 0 ? ' ' : ';');
+            const char* frame_name = fn.name(_frame_buffer[trace._start_frame + j]);
+            out << frame_name << (j == 0 ? ' ' : ';');
         }
         out << (counter == COUNTER_SAMPLES ? trace._samples : trace._counter) << "\n";
     }
@@ -467,6 +468,7 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
+    FrameName fn(true);
     double percent = 100.0 / _total_counter;
     char buf[1024];
 
@@ -486,8 +488,8 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
         }
 
         for (int j = 0; j < trace._num_frames; j++) {
-            FrameName fn(_frame_buffer[trace._start_frame + j], true);
-            snprintf(buf, sizeof(buf), "  [%2d] %s\n", j, fn.toString());
+            const char* frame_name = fn.name(_frame_buffer[trace._start_frame + j]);
+            snprintf(buf, sizeof(buf), "  [%2d] %s\n", j, frame_name);
             out << buf;
         }
         out << "\n";
@@ -498,6 +500,7 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) return;
 
+    FrameName fn(true);
     double percent = 100.0 / _total_counter;
     char buf[1024];
 
@@ -508,9 +511,9 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
         MethodSample& method = _methods[i];
         if (method._samples == 0) break;
 
-        FrameName fn(method._method, true);
+        const char* frame_name = fn.name(method._method);
         snprintf(buf, sizeof(buf), "%12lld (%5.2f%%)  %6lld  %s\n",
-                 method._counter, method._counter * percent, method._samples, fn.toString());
+                 method._counter, method._counter * percent, method._samples, frame_name);
         out << buf;
     }
 }

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -135,6 +135,7 @@ class Profiler {
     int _frame_buffer_size;
     volatile int _frame_buffer_index;
     bool _frame_buffer_overflow;
+    bool _threads;
 
     SpinLock _jit_lock;
     const void* _jit_min_address;
@@ -150,7 +151,7 @@ class Profiler {
     void updateJitRange(const void* min_address, const void* max_address);
 
     const char* findNativeMethod(const void* address);
-    int getNativeTrace(void* ucontext, ASGCT_CallFrame* frames);
+    int getNativeTrace(int tid, ASGCT_CallFrame* frames);
     int getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max_depth);
     int getJavaTraceJVMTI(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int max_depth);
     int makeEventFrame(ASGCT_CallFrame* frames, jint event_type, jmethodID event);
@@ -184,7 +185,7 @@ class Profiler {
     time_t uptime()     { return time(NULL) - _start_time; }
 
     void run(Arguments& args);
-    Error start(const char* event, long interval, int frame_buffer_size);
+    Error start(const char* event, long interval, int frame_buffer_size, bool threads);
     Error stop();
     void dumpSummary(std::ostream& out);
     void dumpCollapsed(std::ostream& out, Counter counter);

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -25,6 +25,7 @@ enum ASGCT_CallFrameType {
     BCI_NATIVE_FRAME       = -10,  // method_id is native function name (char*)
     BCI_KLASS              = -11,  // method_id is Klass descriptor (VMKlass*)
     BCI_KLASS_OUTSIDE_TLAB = -12,  // VMKlass* specifically for allocations outside TLAB
+    BCI_THREAD_ID          = -13,  // method_id designates a thread
 };
 
 typedef struct {

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -24,6 +24,8 @@ int VMStructs::_klass_name_offset = -1;
 int VMStructs::_symbol_length_offset = -1;
 int VMStructs::_symbol_body_offset = -1;
 int VMStructs::_class_klass_offset = -1;
+int VMStructs::_thread_osthread_offset = -1;
+int VMStructs::_osthread_id_offset = -1;
 
 static uintptr_t readSymbol(NativeCodeCache* lib, const char* symbol_name) {
     const void* symbol = lib->findSymbol(symbol_name);
@@ -70,6 +72,14 @@ bool VMStructs::init(NativeCodeCache* libjvm) {
         } else if (strcmp(type, "java_lang_Class") == 0) {
             if (strcmp(field, "_klass_offset") == 0) {
                 _class_klass_offset = **(int**)(entry + address_offset);
+            }
+        } else if (strcmp(type, "JavaThread") == 0) {
+            if (strcmp(field, "_osthread") == 0) {
+                _thread_osthread_offset = *(int*)(entry + offset_offset);
+            }
+        } else if (strcmp(type, "OSThread") == 0) {
+            if (strcmp(field, "_thread_id") == 0) {
+                _osthread_id_offset = *(int*)(entry + offset_offset);
             }
         }
 

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -26,6 +26,8 @@ class VMStructs {
     static int _symbol_length_offset;
     static int _symbol_body_offset;
     static int _class_klass_offset;
+    static int _thread_osthread_offset;
+    static int _osthread_id_offset;
 
     const char* at(int offset) {
         return (const char*)this + offset;
@@ -65,6 +67,18 @@ class java_lang_Class : VMStructs {
   public:
     VMKlass* klass() {
         return *(VMKlass**) at(_class_klass_offset);
+    }
+};
+
+class VMThread : VMStructs {
+  public:
+    static bool available() {
+        return _thread_osthread_offset >= 0 && _osthread_id_offset >= 0;
+    }
+
+    int osThreadId() {
+        const char* osthread = *(const char**) at(_thread_osthread_offset);
+        return *(int*)(osthread + _osthread_id_offset);
     }
 };
 

--- a/test/AllocatingTarget.java
+++ b/test/AllocatingTarget.java
@@ -1,9 +1,15 @@
 import java.util.concurrent.ThreadLocalRandom;
 
-public class AllocatingTarget {
+public class AllocatingTarget implements Runnable {
     public static volatile Object sink;
 
     public static void main(String[] args) {
+        new Thread(new AllocatingTarget(), "AllocThread-1").start();
+        new Thread(new AllocatingTarget(), "AllocThread-2").start();
+    }
+
+    @Override
+    public void run() {
         while (true) {
             allocate();
         }

--- a/test/Target.java
+++ b/test/Target.java
@@ -14,13 +14,13 @@ class Target {
             ++value;
     }
 
-  private static void method3() throws Exception {
-    for (int i = 0; i < 1000; ++i) {
-      for (String s :new File("/tmp").list()) {
-        value += s.hashCode();
-      }
+    private static void method3() throws Exception {
+        for (int i = 0; i < 1000; ++i) {
+            for (String s : new File("/tmp").list()) {
+                value += s.hashCode();
+            }
+        }
     }
-  }
 
     public static void main(String[] args) throws Exception {
         while (true) {

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -22,7 +22,7 @@ fi
   JAVAPID=$!
 
   sleep 1     # allow the Java runtime to initialize
-  ../profiler.sh -f $FILENAME -o collapsed -d 5 -e alloc $JAVAPID
+  ../profiler.sh -f $FILENAME -o collapsed -d 5 -e alloc -t $JAVAPID
 
   kill $JAVAPID
 
@@ -32,6 +32,6 @@ fi
     fi
   }
 
-  assert_string "AllocatingTarget.allocate;.*java.lang.Integer\[\]"
-  assert_string "AllocatingTarget.allocate;.*int\[\]"
+  assert_string "AllocThread-1;.*AllocatingTarget.allocate;.*java.lang.Integer\[\]"
+  assert_string "AllocThread-2;.*AllocatingTarget.allocate;.*int\[\]"
 )


### PR DESCRIPTION
Complement stack traces with a frame denoting a thread.
Use Java thread names where possible. Otherwise fall back to native thread ID.