### PR TITLE
#49: Ability to start profiler together with JVM and dump profile on exit

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -38,14 +38,14 @@ mirror_output() {
 }
 
 check_if_terminated() {
-    if ! kill -0 $PID &> /dev/null; then
+    if ! kill -0 $PID 2> /dev/null; then
         mirror_output
         exit 0
     fi
 }
 
 jattach() {
-    $JATTACH $PID load $PROFILER true $1 > /dev/null
+    $JATTACH $PID load "$PROFILER" true $1 > /dev/null
     RET=$?
 
     # Check if jattach failed
@@ -54,9 +54,9 @@ jattach() {
             echo "Failed to inject profiler into $PID"
             UNAME_S=$(uname -s)
             if [ "$UNAME_S" == "Darwin" ]; then
-                otool -L $PROFILER
+                otool -L "$PROFILER"
             else
-                ldd $PROFILER
+                ldd "$PROFILER"
             fi
         fi
         exit $RET

--- a/profiler.sh
+++ b/profiler.sh
@@ -27,6 +27,23 @@ usage() {
     exit 1
 }
 
+mirror_output() {
+    # Mirror output from temporary file to local terminal
+    if [[ $USE_TMP ]]; then
+        if [[ -f $FILE ]]; then
+            cat $FILE
+            rm $FILE
+        fi
+    fi
+}
+
+check_if_terminated() {
+    if ! kill -0 $PID &> /dev/null; then
+        mirror_output
+        exit 0
+    fi
+}
+
 jattach() {
     $JATTACH $PID load $PROFILER true $1 > /dev/null
     RET=$?
@@ -45,13 +62,7 @@ jattach() {
         exit $RET
     fi
 
-    # Duplicate output from temporary file to local terminal
-    if [[ $USE_TMP ]]; then
-        if [[ -f $FILE ]]; then
-            cat $FILE
-            rm $FILE
-        fi
-    fi
+    mirror_output
 }
 
 function abspath() {
@@ -139,7 +150,7 @@ fi
 
 case $ACTION in
     start)
-        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS
+        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS,$OUTPUT
         ;;
     stop)
         jattach stop,file=$FILE,$OUTPUT
@@ -151,8 +162,11 @@ case $ACTION in
         jattach list,file=$FILE
         ;;
     collect)
-        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS
-        sleep $DURATION
+        jattach start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS,$OUTPUT
+        while (( DURATION-- > 0 )); do
+            check_if_terminated
+            sleep 1
+        done
         jattach stop,file=$FILE,$OUTPUT
         ;;
 esac

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -73,17 +73,13 @@ Error Arguments::parse(const char* args) {
             }
             _event = value;
         } else if (strcmp(arg, "collapsed") == 0 || strcmp(arg, "folded") == 0) {
-            _action = ACTION_DUMP;
             _dump_collapsed = true;
             _counter = value == NULL || strcmp(value, "samples") == 0 ? COUNTER_SAMPLES : COUNTER_TOTAL;
         } else if (strcmp(arg, "summary") == 0) {
-            _action = ACTION_DUMP;
             _dump_summary = true;
         } else if (strcmp(arg, "traces") == 0) {
-            _action = ACTION_DUMP;
             _dump_traces = value == NULL ? INT_MAX : atoi(value);
         } else if (strcmp(arg, "flat") == 0) {
-            _action = ACTION_DUMP;
             _dump_flat = value == NULL ? INT_MAX : atoi(value);
         } else if (strcmp(arg, "interval") == 0) {
             if (value == NULL || (_interval = atol(value)) <= 0) {
@@ -101,6 +97,10 @@ Error Arguments::parse(const char* args) {
             }
             _file = value;
         }
+    }
+
+    if (dumpRequested() && (_action == ACTION_NONE || _action == ACTION_STOP)) {
+        _action = ACTION_DUMP;
     }
 
     return Error::OK;

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -46,10 +46,13 @@ const Error Error::OK(NULL);
 //
 // It is possible to specify multiple dump options at the same time
 
-Error Arguments::parse(char* args) {
-    if (strlen(args) >= sizeof(_buf)) {
+Error Arguments::parse(const char* args) {
+    if (args == NULL) {
+        return Error::OK;
+    } else if (strlen(args) >= sizeof(_buf)) {
         return Error("Argument list too long");
     }
+
     strcpy(_buf, args);
 
     for (char* arg = strtok(_buf, ","); arg != NULL; arg = strtok(NULL, ",")) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -49,9 +49,6 @@ class Error {
   public:
     static const Error OK;
 
-    Error() {
-    }
-
     explicit Error(const char* message) : _message(message) {
     }
 
@@ -68,9 +65,6 @@ class Error {
 class Arguments {
   private:
     char _buf[1024];
-    Error _error;
-
-    Error parse(char* args);
 
   public:
     Action _action;
@@ -85,7 +79,7 @@ class Arguments {
     int _dump_traces;
     int _dump_flat;
 
-    Arguments(char* args) :
+    Arguments() :
         _action(ACTION_NONE),
         _counter(COUNTER_SAMPLES),
         _event(EVENT_CPU),
@@ -97,12 +91,13 @@ class Arguments {
         _dump_summary(false),
         _dump_traces(0),
         _dump_flat(0) {
-        _error = parse(args);
     }
 
-    Error error() {
-        return _error;
+    bool dumpRequested() {
+        return _dump_collapsed || _dump_summary || _dump_traces > 0 || _dump_flat > 0;
     }
+
+    Error parse(const char* args);
 };
 
 #endif // _ARGUMENTS_H

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -29,9 +29,12 @@ static void throw_illegal_state(JNIEnv* env, const char* message) {
 
 extern "C" JNIEXPORT void JNICALL
 Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jstring event, jlong interval) {
-    const char* event_str = env->GetStringUTFChars(event, NULL);
-    Error error = Profiler::_instance.start(event_str, interval, DEFAULT_FRAMEBUF, false);
-    env->ReleaseStringUTFChars(event, event_str);
+    Arguments args;
+    args._event = env->GetStringUTFChars(event, NULL);
+    args._interval = interval;
+
+    Error error = Profiler::_instance.start(args);
+    env->ReleaseStringUTFChars(event, args._event);
 
     if (error) {
         throw_illegal_state(env, error.message());

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -29,12 +29,9 @@ static void throw_illegal_state(JNIEnv* env, const char* message) {
 
 extern "C" JNIEXPORT void JNICALL
 Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jstring event, jlong interval) {
-    Arguments args;
-    args._event = env->GetStringUTFChars(event, NULL);
-    args._interval = interval;
-
-    Error error = Profiler::_instance.start(args);
-    env->ReleaseStringUTFChars(event, args._event);
+    const char* event_str = env->GetStringUTFChars(event, NULL);
+    Error error = Profiler::_instance.start(event_str, interval, DEFAULT_FRAMEBUF, false);
+    env->ReleaseStringUTFChars(event, event_str);
 
     if (error) {
         throw_illegal_state(env, error.message());

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -247,21 +247,6 @@ int Profiler::getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max
     return 0;
 }
 
-int Profiler::getJavaTraceJVMTI(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int max_depth) {
-    jint num_frames;
-    if (VM::jvmti()->GetStackTrace(NULL, 0, max_depth, jvmti_frames, &num_frames) == 0 && num_frames > 0) {
-        // Profiler expects stack trace in AsyncGetCallTrace format; convert it now
-        for (int i = 0; i < num_frames; i++) {
-            frames[i].method_id = jvmti_frames[i].method;
-            frames[i].bci = 0;
-        }
-        return num_frames;
-    }
-
-    atomicInc(_failures[-ticks_no_Java_frame]);
-    return 0;
-}
-
 int Profiler::makeEventFrame(ASGCT_CallFrame* frames, jint event_type, jmethodID event) {
     frames[0].bci = event_type;
     frames[0].method_id = event;
@@ -298,19 +283,12 @@ void Profiler::recordSample(void* ucontext, u64 counter, jint event_type, jmetho
 
     atomicInc(_total_counter, counter);
 
-    ASGCT_CallFrame* frames = _calltrace_buffer[lock_index]._asgct_frames;
-    int num_frames;
+    ASGCT_CallFrame* frames = _calltrace_buffer[lock_index];
     int tid = PerfEvents::tid();
 
-    if (event == NULL) {
-        num_frames = getNativeTrace(tid, frames);
-        num_frames += getJavaTraceAsync(ucontext, frames + num_frames, MAX_STACK_FRAMES - 1 - num_frames);
-    } else {
-        // Events like object allocation happen at known places where it is safe to call JVM TI
-        jvmtiFrameInfo* jvmti_frames = _calltrace_buffer[lock_index]._jvmti_frames;
-        num_frames = makeEventFrame(frames, event_type, event);
-        num_frames += getJavaTraceJVMTI(jvmti_frames + num_frames, frames + num_frames, MAX_STACK_FRAMES - 1 - num_frames);
-    }
+    int num_frames = event != NULL ? makeEventFrame(frames, event_type, event) : 0;
+    num_frames += getNativeTrace(tid, frames);
+    num_frames += getJavaTraceAsync(ucontext, frames + num_frames, MAX_STACK_FRAMES - 1 - num_frames);
 
     if (_threads) {
         num_frames += makeEventFrame(frames + num_frames, BCI_THREAD_ID, (jmethodID)(uintptr_t)tid);

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -40,12 +40,6 @@ static inline int cmp64(u64 a, u64 b) {
 }
 
 
-union CallTraceBuffer {
-    ASGCT_CallFrame _asgct_frames[MAX_STACK_FRAMES];
-    jvmtiFrameInfo _jvmti_frames[MAX_STACK_FRAMES];
-};
-
-
 class CallTraceSample {
   private:
     u64 _samples;
@@ -130,7 +124,7 @@ class Profiler {
     MethodSample _methods[MAX_CALLTRACES];
 
     SpinLock _locks[CONCURRENCY_LEVEL];
-    CallTraceBuffer _calltrace_buffer[CONCURRENCY_LEVEL];
+    ASGCT_CallFrame _calltrace_buffer[CONCURRENCY_LEVEL][MAX_STACK_FRAMES];
     ASGCT_CallFrame* _frame_buffer;
     int _frame_buffer_size;
     volatile int _frame_buffer_index;
@@ -153,7 +147,6 @@ class Profiler {
     const char* findNativeMethod(const void* address);
     int getNativeTrace(int tid, ASGCT_CallFrame* frames);
     int getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max_depth);
-    int getJavaTraceJVMTI(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int max_depth);
     int makeEventFrame(ASGCT_CallFrame* frames, jint event_type, jmethodID event);
     bool fillTopFrame(const void* pc, ASGCT_CallFrame* frame);
     u64 hashCallTrace(int num_frames, ASGCT_CallFrame* frames);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -98,7 +98,7 @@ void VM::loadMethodIDs(jvmtiEnv* jvmti, jclass klass) {
     }
 }
 
-void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+void VM::loadAllMethodIDs(jvmtiEnv* jvmti) {
     jint class_count;
     jclass* classes;
     if (jvmti->GetLoadedClasses(&class_count, &classes) == 0) {
@@ -107,7 +107,10 @@ void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         }
         jvmti->Deallocate((unsigned char*)classes);
     }
+}
 
+void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+    loadAllMethodIDs(jvmti);
     // Delayed start of profiler if agent has been loaded at VM bootstrap
     Profiler::_instance.run(_startup_args);
 }

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -65,6 +65,7 @@ class VM {
     }
 
     static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
+    static void JNICALL VMDeath(jvmtiEnv* jvmti, JNIEnv* jni);
 
     static void JNICALL ClassLoad(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jclass klass) {
         // Needed only for AsyncGetCallTrace support

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -64,9 +64,7 @@ class VM {
         return _vm->GetEnv((void**)&jni, JNI_VERSION_1_6) == 0 ? jni : NULL;
     }
 
-    static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
-        loadAllMethodIDs(jvmti);
-    }
+    static void JNICALL VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
 
     static void JNICALL ClassLoad(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jclass klass) {
         // Needed only for AsyncGetCallTrace support


### PR DESCRIPTION
- Profiler can start immediately after JVM bootstrap, if specified with `-agentpath` option
- Dump collected data if JVM terminates prematurely
- profiler.sh script exits as soon as target JVM dies