### PR TITLE
Check if PAGE_SIZE is already defined.

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -20,7 +20,9 @@
 
 typedef unsigned long long u64;
 
+#ifndef PAGE_SIZE
 const unsigned long PAGE_SIZE = 4096;
+#endif
 const unsigned long PAGE_MASK = PAGE_SIZE - 1;
 
 


### PR DESCRIPTION
Fixes compile on alpine linux where PAGE_SIZE is already defined in /usr/include/bits/limits.h (and included via /usr/include/limits.h)