### PR TITLE
#90: Profile ReentrantLock contention

### DIFF
--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -14,12 +14,15 @@
  * limitations under the License.
  */
 
+#include <dlfcn.h>
 #include "lockTracer.h"
 #include "profiler.h"
 #include "vmStructs.h"
 
 
 jlong LockTracer::_start_time = 0;
+UnsafeParkFunc LockTracer::_real_unsafe_park = NULL;
+jfieldID LockTracer::_thread_parkBlocker = NULL;
 
 Error LockTracer::start(const char* event, long interval) {
     NativeCodeCache* libjvm = Profiler::_instance.jvmLibrary();
@@ -31,15 +34,42 @@ Error LockTracer::start(const char* event, long interval) {
         return Error("VMStructs unavailable. Unsupported JVM?");
     }
 
-    if (VMStructs::hasPermGen()) {
-        return Error("Lock profiling is supported on JDK 8+");
-    }
-
+    // Enable Java Monitor events
     jvmtiEnv* jvmti = VM::jvmti();
     jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL);
     jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL);
-
     jvmti->GetTime(&_start_time);
+
+    // Intercent Unsafe.park() for tracing contended ReentrantLocks
+    if (_real_unsafe_park == NULL) {
+        _real_unsafe_park = (UnsafeParkFunc)libjvm->findSymbol("Unsafe_Park");
+    }
+
+    JNIEnv* env = VM::jni();
+    if (env != NULL && _real_unsafe_park != NULL) {
+        // Cache Thread.parkBlocker field
+        if (_thread_parkBlocker == NULL) {
+            jclass thread = env->FindClass("java/lang/Thread");
+            if (thread != NULL) {
+                _thread_parkBlocker = env->GetFieldID(thread, "parkBlocker", "Ljava/lang/Object;");
+                env->DeleteLocalRef(thread);
+            }
+
+            if (_thread_parkBlocker == NULL) {
+                return Error::OK;
+            }
+        }
+
+        // Try JDK 9+ package first, then fallback to JDK 8 package
+        jclass unsafe = env->FindClass("jdk/internal/misc/Unsafe");
+        if (unsafe == NULL) unsafe = env->FindClass("sun/misc/Unsafe");
+        if (unsafe != NULL) {
+            const JNINativeMethod unsafe_park = {(char*)"park", (char*)"(ZJ)V", (void*)LockTracer::UnsafePark};
+            jint result = env->RegisterNatives(unsafe, &unsafe_park, 1);
+            printf("Registered Unsafe native: %d\n", result);
+            env->DeleteLocalRef(unsafe);
+        }
+    }
 
     return Error::OK;
 }
@@ -62,11 +92,41 @@ void JNICALL LockTracer::MonitorContendedEntered(jvmtiEnv* jvmti, JNIEnv* env, j
     jvmti->GetTag(thread, &enter_time);
 
     // Time is meaningless if lock attempt has started before profiling
-    if (enter_time < _start_time) {
-        return;
+    if (enter_time >= _start_time) {
+        recordContendedLock(env, entered_time - enter_time, object);
+    }
+}
+
+void JNICALL LockTracer::UnsafePark(JNIEnv* env, jobject instance, jboolean isAbsolute, jlong time) {
+    jobject park_blocker = NULL;
+    jlong park_start_time, park_end_time;
+
+    jvmtiEnv* jvmti = VM::jvmti();
+    jthread thread;
+    if (jvmti->GetCurrentThread(&thread) == 0) {
+        park_blocker = env->GetObjectField(thread, _thread_parkBlocker);
     }
 
-    jclass lock_class = env->GetObjectClass(object);
-    VMSymbol* lock_name = (*(java_lang_Class**)lock_class)->klass()->name();
-    Profiler::_instance.recordSample(NULL, entered_time - enter_time, BCI_SYMBOL, (jmethodID)lock_name);
+    if (park_blocker != NULL) {
+        jvmti->GetTime(&park_start_time);
+    }
+    
+    _real_unsafe_park(env, instance, isAbsolute, time);
+
+    if (park_blocker != NULL) {
+        jvmti->GetTime(&park_end_time);
+        recordContendedLock(env, park_end_time - park_start_time, park_blocker);
+    }
+}
+
+void LockTracer::recordContendedLock(JNIEnv* env, jlong time, jobject lock) {
+    if (VMStructs::hasPermGen()) {
+        // PermGen in JDK 7 makes difficult to get symbol name from jclass.
+        // Let's just skip it and record stack trace without lock class.
+        Profiler::_instance.recordSample(NULL, time, 0, NULL);
+    } else {
+        jclass lock_class = env->GetObjectClass(lock);
+        VMSymbol* lock_name = (*(java_lang_Class**)lock_class)->klass()->name();
+        Profiler::_instance.recordSample(NULL, time, BCI_SYMBOL, (jmethodID)lock_name);
+    }
 }

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#include <dlfcn.h>
 #include <string.h>
 #include "lockTracer.h"
 #include "profiler.h"

--- a/src/lockTracer.h
+++ b/src/lockTracer.h
@@ -26,10 +26,13 @@ typedef void (JNICALL *UnsafeParkFunc)(JNIEnv*, jobject, jboolean, jlong);
 class LockTracer : public Engine {
   private:
     static jlong _start_time;
-    static UnsafeParkFunc _real_unsafe_park;
-    static jfieldID _thread_parkBlocker;
+    static jclass _LockSupport;
+    static jmethodID _getBlocker;
+    static UnsafeParkFunc _original_Unsafe_Park;
 
-    static void recordContendedLock(JNIEnv* env, jlong time, jobject lock);
+    static jclass getParkBlockerClass(jvmtiEnv* jvmti, JNIEnv* env);
+    static void recordContendedLock(jclass lock_class, jlong time);
+    static void bindUnsafePark(UnsafeParkFunc entry);
 
   public:
     const char* name() {
@@ -41,7 +44,7 @@ class LockTracer : public Engine {
 
     static void JNICALL MonitorContendedEnter(jvmtiEnv* jvmti, JNIEnv* env, jthread thread, jobject object);
     static void JNICALL MonitorContendedEntered(jvmtiEnv* jvmti, JNIEnv* env, jthread thread, jobject object);
-    static void JNICALL UnsafePark(JNIEnv* env, jobject instance, jboolean isAbsolute, jlong time);
+    static void JNICALL UnsafeParkTrap(JNIEnv* env, jobject instance, jboolean isAbsolute, jlong time);
 };
 
 #endif // _LOCKTRACER_H

--- a/src/lockTracer.h
+++ b/src/lockTracer.h
@@ -21,9 +21,15 @@
 #include "engine.h"
 
 
+typedef void (JNICALL *UnsafeParkFunc)(JNIEnv*, jobject, jboolean, jlong);
+
 class LockTracer : public Engine {
   private:
     static jlong _start_time;
+    static UnsafeParkFunc _real_unsafe_park;
+    static jfieldID _thread_parkBlocker;
+
+    static void recordContendedLock(JNIEnv* env, jlong time, jobject lock);
 
   public:
     const char* name() {
@@ -35,6 +41,7 @@ class LockTracer : public Engine {
 
     static void JNICALL MonitorContendedEnter(jvmtiEnv* jvmti, JNIEnv* env, jthread thread, jobject object);
     static void JNICALL MonitorContendedEntered(jvmtiEnv* jvmti, JNIEnv* env, jthread thread, jobject object);
+    static void JNICALL UnsafePark(JNIEnv* env, jobject instance, jboolean isAbsolute, jlong time);
 };
 
 #endif // _LOCKTRACER_H


### PR DESCRIPTION
Substitute `Unsafe.park()` native entry to measure `park()` time of ReentrantLocks.