### PR TITLE
#101: Determine actual page size on Linux

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -17,18 +17,18 @@
 #ifndef _ARCH_H
 #define _ARCH_H
 
-#ifdef __linux__
+#ifdef __unix__
 #include <unistd.h>
-#endif //__linux__
+#endif //__unix__
 
 typedef unsigned long long u64;
 
 #ifndef PAGE_SIZE
-#ifdef __linux__
+#ifdef __unix__
 const unsigned long PAGE_SIZE = sysconf(_SC_PAGESIZE);
 #else
 const unsigned long PAGE_SIZE = 4096;
-#endif //__linux__
+#endif //__unix__
 #endif //PAGE_SIZE
 const unsigned long PAGE_MASK = PAGE_SIZE - 1;
 

--- a/src/arch.h
+++ b/src/arch.h
@@ -17,12 +17,19 @@
 #ifndef _ARCH_H
 #define _ARCH_H
 
+#ifdef __linux__
+#include <unistd.h>
+#endif //__linux__
 
 typedef unsigned long long u64;
 
 #ifndef PAGE_SIZE
+#ifdef __linux__
+const unsigned long PAGE_SIZE = sysconf(_SC_PAGESIZE);
+#else
 const unsigned long PAGE_SIZE = 4096;
-#endif
+#endif //__linux__
+#endif //PAGE_SIZE
 const unsigned long PAGE_MASK = PAGE_SIZE - 1;
 
 


### PR DESCRIPTION
Use sysconf(_SC_PAGESIZE) instead of 4k.