### PR TITLE
Option to limit java stack depth to reduce CPU overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ is counted. No samples are collected while CPU is idle. The default is
 Example: `./profiler.sh -i 100000 8983`
 
 * `-j N` - sets the java stack profiling depth. This option will be ignored if N is greater 
-than default MAX_STACK_FRAMES.
+than default MAX_STACK_FRAMES. 
 Example: `./profiler.sh -j 30 8983`
 
 * `-b N` - sets the frame buffer size, in the number of Java

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ is counted. No samples are collected while CPU is idle. The default is
 Example: `./profiler.sh -i 100000 8983`
 
 * `-j N` - sets the java stack profiling depth. This option will be ignored if N is greater 
-than default MAX_STACK_FRAMES. 
+than default MAX_STACK_FRAMES.  
 Example: `./profiler.sh -j 30 8983`
 
 * `-b N` - sets the frame buffer size, in the number of Java

--- a/README.md
+++ b/README.md
@@ -216,6 +216,10 @@ is counted. No samples are collected while CPU is idle. The default is
 1000000 (1ms).  
 Example: `./profiler.sh -i 100000 8983`
 
+* `-j N` - sets the java stack profiling depth. This option will be ignored if N is greater 
+than default MAX_STACK_FRAMES.
+Example: `./profiler.sh -j 30 8983`
+
 * `-b N` - sets the frame buffer size, in the number of Java
 method ids that should fit in the buffer. If you receive messages about an
 insufficient frame buffer size, increase this value from the default.  

--- a/profiler.sh
+++ b/profiler.sh
@@ -96,6 +96,7 @@ FRAMEBUF=""
 THREADS=""
 OUTPUT=""
 FORMAT=""
+JSTACKDEPTH=""
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -111,6 +112,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -d)
             DURATION="$2"
+            shift
+            ;;
+        -j)
+            JSTACKDEPTH=",jstackdepth=$2"
             shift
             ;;
         -f)
@@ -188,7 +193,7 @@ fi
 
 case $ACTION in
     start)
-        jattach "start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS,$OUTPUT$FORMAT"
+        jattach "start,event=$EVENT,file=$FILE$INTERVAL$JSTACKDEPTH$FRAMEBUF$THREADS,$OUTPUT$FORMAT"
         ;;
     stop)
         jattach "stop,file=$FILE,$OUTPUT$FORMAT"
@@ -200,7 +205,7 @@ case $ACTION in
         jattach "list,file=$FILE"
         ;;
     collect)
-        jattach "start,event=$EVENT,file=$FILE$INTERVAL$FRAMEBUF$THREADS,$OUTPUT$FORMAT"
+        jattach "start,event=$EVENT,file=$FILE$INTERVAL$JSTACKDEPTH$FRAMEBUF$THREADS,$OUTPUT$FORMAT"
         while (( DURATION-- > 0 )); do
             check_if_terminated
             sleep 1

--- a/profiler.sh
+++ b/profiler.sh
@@ -14,6 +14,7 @@ usage() {
     echo "  -d duration       run profiling for <duration> seconds"
     echo "  -f filename       dump output to <filename>"
     echo "  -i interval       sampling interval in nanoseconds"
+    echo "  -j jstackdepth    java stack depth"
     echo "  -b bufsize        frame buffer size"
     echo "  -t                profile different threads separately"
     echo "  -s                simple class names instead of FQN"

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -40,6 +40,7 @@ const Error Error::OK(NULL);
 //     traces[=N]    - dump top N call traces
 //     flat[=N]      - dump top N methods (aka flat profile)
 //     interval=N    - sampling interval in ns (default: 1'000'000, i.e. 1 ms)
+//     jstackdepth=N - java stack depth (default: MAX_STACK_FRAMES, will be ignored if the option is greater than default)
 //     framebuf=N    - size of the buffer for stack frames (default: 1'000'000)
 //     threads       - profile different threads separately
 //     simple        - simple class names instead of FQN

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -19,7 +19,6 @@
 #include <string.h>
 #include "arguments.h"
 
-
 // Predefined value that denotes successful operation
 const Error Error::OK(NULL);
 
@@ -94,6 +93,10 @@ Error Arguments::parse(const char* args) {
         } else if (strcmp(arg, "interval") == 0) {
             if (value == NULL || (_interval = atol(value)) <= 0) {
                 return Error("interval must be > 0");
+            }
+        } else if (strcmp(arg, "jstackdepth") == 0) {
+            if (value == NULL || (_jstackdepth = atol(value)) <= 0) {
+                return Error("jstackdepth must be > 0");
             }
         } else if (strcmp(arg, "framebuf") == 0) {
             if (value == NULL || (_framebuf = atoi(value)) <= 0) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -71,7 +71,7 @@ class Arguments {
     Counter _counter;
     const char* _event;
     long _interval;
-    long _jstackdepth;
+    int  _jstackdepth;
     int _framebuf;
     bool _threads;
     bool _simple;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -93,7 +93,7 @@ class Arguments {
         _counter(COUNTER_SAMPLES),
         _event(EVENT_CPU),
         _interval(0),
-	_jstackdepth(0),
+        _jstackdepth(0),
         _framebuf(DEFAULT_FRAMEBUF),
         _threads(false),
         _simple(false),

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -71,6 +71,7 @@ class Arguments {
     Counter _counter;
     const char* _event;
     long _interval;
+    long _jstackdepth;
     int _framebuf;
     bool _threads;
     bool _simple;
@@ -92,6 +93,7 @@ class Arguments {
         _counter(COUNTER_SAMPLES),
         _event(EVENT_CPU),
         _interval(0),
+	_jstackdepth(0),
         _framebuf(DEFAULT_FRAMEBUF),
         _threads(false),
         _simple(false),

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -338,7 +338,11 @@ void Profiler::recordSample(void* ucontext, u64 counter, jint event_type, jmetho
     }
 
     if (event == NULL || _JvmtiEnv_GetStackTrace == NULL) {
-        num_frames += getJavaTraceAsync(ucontext, frames + num_frames, MAX_STACK_FRAMES - 1 - num_frames);
+	int max_depth = MAX_STACK_FRAMES - 1 - num_frames;
+	if( _jstackdepth != 0 && _jstackdepth < max_depth) {
+		max_depth =  _jstackdepth + 1 + num_frames;
+	}
+       	num_frames += getJavaTraceAsync(ucontext, frames + num_frames, max_depth);
     } else {
         // Events like object allocation happen at known places where it is safe to call JVM TI
         jvmtiFrameInfo* jvmti_frames = _calltrace_buffer[lock_index]._jvmti_frames;
@@ -397,7 +401,6 @@ Error Profiler::start(const char* event, long interval, int frame_buffer_size, b
     if (_state != IDLE) {
         return Error("Profiler already started");
     }
-
     if (VM::_asyncGetCallTrace == NULL) {
         return Error("Could not find AsyncGetCallTrace function");
     }
@@ -614,6 +617,7 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
 void Profiler::runInternal(Arguments& args, std::ostream& out) {
     switch (args._action) {
         case ACTION_START: {
+	    if(strcmp(args._event,"cpu") == 0) { _jstackdepth = args._jstackdepth; }
             Error error = start(args._event, args._interval, args._framebuf, args._threads);
             if (error) {
                 out << error.message() << std::endl;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -338,11 +338,11 @@ void Profiler::recordSample(void* ucontext, u64 counter, jint event_type, jmetho
     }
 
     if (event == NULL || _JvmtiEnv_GetStackTrace == NULL) {
-	int max_depth = MAX_STACK_FRAMES - 1 - num_frames;
-	if( _jstackdepth != 0 && _jstackdepth < max_depth) {
+        int max_depth = MAX_STACK_FRAMES - 1 - num_frames;
+        if( _jstackdepth != 0 && _jstackdepth < max_depth) {
 		max_depth =  _jstackdepth + 1 + num_frames;
-	}
-       	num_frames += getJavaTraceAsync(ucontext, frames + num_frames, max_depth);
+        }
+        num_frames += getJavaTraceAsync(ucontext, frames + num_frames, max_depth);
     } else {
         // Events like object allocation happen at known places where it is safe to call JVM TI
         jvmtiFrameInfo* jvmti_frames = _calltrace_buffer[lock_index]._jvmti_frames;
@@ -617,7 +617,7 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
 void Profiler::runInternal(Arguments& args, std::ostream& out) {
     switch (args._action) {
         case ACTION_START: {
-	    if(strcmp(args._event,"cpu") == 0) { _jstackdepth = args._jstackdepth; }
+            if(strcmp(args._event,"cpu") == 0) { _jstackdepth = args._jstackdepth; }
             Error error = start(args._event, args._interval, args._framebuf, args._threads);
             if (error) {
                 out << error.message() << std::endl;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -340,7 +340,7 @@ void Profiler::recordSample(void* ucontext, u64 counter, jint event_type, jmetho
     if (event == NULL || _JvmtiEnv_GetStackTrace == NULL) {
         int max_depth = MAX_STACK_FRAMES - 1 - num_frames;
         if( _jstackdepth != 0 && _jstackdepth < max_depth) {
-		max_depth =  _jstackdepth + 1 + num_frames;
+		max_depth =  _jstackdepth;
         }
         num_frames += getJavaTraceAsync(ucontext, frames + num_frames, max_depth);
     } else {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -617,7 +617,7 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
 void Profiler::runInternal(Arguments& args, std::ostream& out) {
     switch (args._action) {
         case ACTION_START: {
-            if(strcmp(args._event,"cpu") == 0) { _jstackdepth = args._jstackdepth; }
+            _jstackdepth = args._jstackdepth;//this is used in AsyncGetCallTrace to control java stack depth
             Error error = start(args._event, args._interval, args._framebuf, args._threads);
             if (error) {
                 out << error.message() << std::endl;

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -144,7 +144,7 @@ class Profiler {
     NativeCodeCache _runtime_stubs;
     NativeCodeCache* _native_libs[MAX_NATIVE_LIBS];
     int _native_lib_count;
-
+    long _jstackdepth;
     void* (*_ThreadLocalStorage_thread)();
     jvmtiError (*_JvmtiEnv_GetStackTrace)(void* self, void* thread, jint start_depth, jint max_frame_count,
                                           jvmtiFrameInfo* frame_buffer, jint* count_ptr);
@@ -184,7 +184,8 @@ class Profiler {
         _runtime_stubs("[stubs]"),
         _native_lib_count(0),
         _ThreadLocalStorage_thread(NULL),
-        _JvmtiEnv_GetStackTrace(NULL) {
+        _JvmtiEnv_GetStackTrace(NULL),
+	_jstackdepth(0) {
         initStateLock();
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -185,7 +185,7 @@ class Profiler {
         _native_lib_count(0),
         _ThreadLocalStorage_thread(NULL),
         _JvmtiEnv_GetStackTrace(NULL),
-	_jstackdepth(0) {
+        _jstackdepth(0) {
         initStateLock();
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -144,7 +144,7 @@ class Profiler {
     NativeCodeCache _runtime_stubs;
     NativeCodeCache* _native_libs[MAX_NATIVE_LIBS];
     int _native_lib_count;
-    long _jstackdepth;
+    int _jstackdepth;
     void* (*_ThreadLocalStorage_thread)();
     jvmtiError (*_JvmtiEnv_GetStackTrace)(void* self, void* thread, jint start_depth, jint max_frame_count,
                                           jvmtiFrameInfo* frame_buffer, jint* count_ptr);


### PR DESCRIPTION
We have experimented with reduced java stack and observed less CPU overhead. This could be a useful option for others too.

Added a new option "-j jstackdepth" to control the java stack depth that AsyncGetCallTrace fetches.

Conditions are added to make sure that the total stack frames (native+java) are not exceeding MAX_STACK_FRAMES.

This option is applied only when event type is "cpu"