### PR TITLE
Pass JAVA_HOME variable to test scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ JAVAC=$(JAVA_HOME)/bin/javac
 JAR=$(JAVA_HOME)/bin/jar
 
 ifeq ($(JAVA_HOME),)
-  JAVA_HOME:=$(shell java -cp . JavaHome)
+  export JAVA_HOME:=$(shell java -cp . JavaHome)
 endif
 
 OS:=$(shell uname -s)

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -3,16 +3,15 @@
 set -e  # exit on any failure
 set -x  # print all executed lines
 
-if [ -z "${JAVA_HOME}" ]
-then
+if [ -z "${JAVA_HOME}" ]; then
   echo "JAVA_HOME is not set"
+  exit 1
 fi
 
 (
   cd $(dirname $0)
 
-  if [ "AllocatingTarget.class" -ot "AllocatingTarget.java" ]
-  then
+  if [ "AllocatingTarget.class" -ot "AllocatingTarget.java" ]; then
      ${JAVA_HOME}/bin/javac AllocatingTarget.java
   fi
 

--- a/test/smoke-test.sh
+++ b/test/smoke-test.sh
@@ -3,16 +3,15 @@
 set -e  # exit on any failure
 set -x  # print all executed lines
 
-if [ -z "${JAVA_HOME}" ]
-then
+if [ -z "${JAVA_HOME}" ]; then
   echo "JAVA_HOME is not set"
+  exit 1
 fi
 
 (
   cd $(dirname $0)
 
-  if [ "Target.class" -ot "Target.java" ]
-  then
+  if [ "Target.class" -ot "Target.java" ]; then
      ${JAVA_HOME}/bin/javac Target.java
   fi
 


### PR DESCRIPTION
Hi,

I found the issue:
```
$ make test
test/smoke-test.sh
+ '[' -z '' ']'
+ echo 'JAVA_HOME is not set'
JAVA_HOME is not set
```
when dynamically calculated `JAVA_HOME` variable is not passed to test scripts, like `smoke-test.sh` and `alloc-smoke-test.sh`.

This PR adds export of `JAVA_HOME` variable to the environment of subsequently executed commands.