### PR TITLE
README: add note about how to build icedtea with symbols on Gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Debian / Ubuntu, run
 ```
 # apt-get install openjdk-8-dbg
 ```
-On Gentoo the ``icedtea`` OpenJKD can be built with the per-package setting
+On Gentoo the ``icedtea`` OpenJDK can be built with the per-package setting
 ``FEATURES="nostrip"`` to retain symbols.
 
 ## Supported platforms

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Debian / Ubuntu, run
 ```
 # apt-get install openjdk-8-dbg
 ```
+On Gentoo the ``icedtea`` OpenJKD can be built with the per-package setting
+``FEATURES="nostrip"`` to retain symbols.
 
 ## Supported platforms
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Debian / Ubuntu, run
 ```
 # apt-get install openjdk-8-dbg
 ```
-On Gentoo the ``icedtea`` OpenJDK can be built with the per-package setting
+On Gentoo the ``icedtea`` OpenJDK package can be built with the per-package setting
 ``FEATURES="nostrip"`` to retain symbols.
 
 ## Supported platforms


### PR DESCRIPTION
This commit adds a brief yet not-completely-obvious note about how to get symbols into the
'icedtea' OpenJDK package on Gentoo Linux. The approach worked for me when I
tried async-profiler last night and (of course) initially had no symbols;  after rebuilding icedtea
with "nostrip" I got perfectly good profiles.