### PR TITLE
Improve JVM thread names support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ build/$(PROFILER_JAR): src/java/one/profiler/*.java
 test: all
 	test/smoke-test.sh
 	test/alloc-smoke-test.sh
+	test/thread-smoke-test.sh
 
 clean:
 	rm -rf build

--- a/src/concurrencyUtil.cpp
+++ b/src/concurrencyUtil.cpp
@@ -1,0 +1,8 @@
+#include "concurrencyUtil.h"
+
+void initLock(pthread_mutex_t* lock) {
+    pthread_mutexattr_t attr;
+    pthread_mutexattr_init(&attr);
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+    pthread_mutex_init(lock, &attr);
+}

--- a/src/concurrencyUtil.h
+++ b/src/concurrencyUtil.h
@@ -1,0 +1,23 @@
+#ifndef _CONCURRENCYUTIL_H
+#define _CONCURRENCYUTIL_H
+
+#include <pthread.h>
+
+
+class MutexLocker {
+private:
+    pthread_mutex_t* _mutex;
+
+public:
+    MutexLocker(pthread_mutex_t& mutex) : _mutex(&mutex) {
+        pthread_mutex_lock(_mutex);
+    }
+
+    ~MutexLocker() {
+        pthread_mutex_unlock(_mutex);
+    }
+};
+
+void initLock(pthread_mutex_t* lock);
+
+#endif //_CONCURRENCYUTIL_H

--- a/src/engine.h
+++ b/src/engine.h
@@ -27,6 +27,9 @@ class Engine {
     virtual Error start(const char* event, long interval) = 0;
     virtual void stop() = 0;
 
+    virtual void onThreadStart() {}
+    virtual void onThreadEnd() {}
+
     virtual ~Engine() {}
 };
 

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -21,6 +21,7 @@
 #include "frameName.h"
 #include "vmStructs.h"
 #include "threadNames.h"
+#include "profiler.h"
 
 
 FrameName::FrameName(bool simple, bool dotted, bool use_thread_names) :
@@ -32,8 +33,9 @@ FrameName::FrameName(bool simple, bool dotted, bool use_thread_names) :
     _saved_locale = uselocale(newlocale(LC_NUMERIC_MASK, "C", (locale_t)0));
 
     if (use_thread_names) {
-        updateAllKnownThreads();
-        _thread_names = ThreadNames::_instance.getNames();
+        ThreadNames storage = Profiler::_instance.threadNames();
+        storage.updateAllKnownThreads();
+        _thread_names = storage.getNames();
     }
 }
 

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -22,24 +22,11 @@
 #include <map>
 #include <string>
 #include "vmEntry.h"
+#include "threadNames.h"
 
 #ifdef __APPLE__
 #  include <xlocale.h>
 #endif
-
-
-class ThreadId {
-  private:
-    int _id;
-    const char* _name;
-
-  public:
-    static int comparator(const void* t1, const void* t2) {
-        return ((ThreadId*)t1)->_id - ((ThreadId*)t2)->_id;
-    }
-
-    friend class FrameName;
-};
 
 
 typedef std::map<jmethodID, std::string> JMethodCache;
@@ -51,10 +38,8 @@ class FrameName {
     bool _simple;
     bool _dotted;
     locale_t _saved_locale;
-    int _thread_count;
-    ThreadId* _threads;
+    NamesMap _thread_names;
 
-    void initThreadMap();
     const char* findThreadName(int tid);
     const char* cppDemangle(const char* name);
     char* javaMethodName(jmethodID method);

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -32,7 +32,6 @@ class PerfEvents : public Engine {
     static PerfEvent* _events;
     static PerfEventType* _event_type;
     static long _interval;
-    static bool _is_active;
 
     static bool createForThread(int tid);
     static bool createForAllThreads();
@@ -40,10 +39,6 @@ class PerfEvents : public Engine {
     static void destroyForAllThreads();
     static void installSignalHandler();
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
-
-    static void setActive(bool value) {
-        __atomic_store_n(&_is_active, value, __ATOMIC_SEQ_CST);
-    }
 
   public:
     const char* name() {
@@ -58,20 +53,12 @@ class PerfEvents : public Engine {
     static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
                             const void* jit_min_address, const void* jit_max_address);
 
-    static bool isActive() {
-        return __atomic_load_n(&_is_active, __ATOMIC_SEQ_CST);
+    void onThreadStart() {
+        createForThread(tid());
     }
 
-    static void onThreadStart() {
-        if (isActive()) {
-            createForThread(tid());
-        }
-    }
-
-    static void onThreadEnd() {
-        if (isActive()) {
-            destroyForThread(tid());
-        }
+    void onThreadEnd() {
+        destroyForThread(tid());
     }
 };
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -289,6 +289,7 @@ int PerfEvents::_max_events = 0;
 PerfEvent* PerfEvents::_events = NULL;
 PerfEventType* PerfEvents::_event_type = NULL;
 long PerfEvents::_interval;
+bool PerfEvents::_is_active = false;
 
 int PerfEvents::tid() {
     return syscall(__NR_gettid);
@@ -445,21 +446,15 @@ Error PerfEvents::start(const char* event, long interval) {
     
     installSignalHandler();
 
-    jvmtiEnv* jvmti = VM::jvmti();
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_START, NULL);
-    jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_THREAD_END, NULL);
-
     if (!createForAllThreads()) {
         return Error("Perf events unavailble. See stderr of the target process.");
     }
+    setActive(true);
     return Error::OK;
 }
 
 void PerfEvents::stop() {
-    jvmtiEnv* jvmti = VM::jvmti();
-    jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_THREAD_START, NULL);
-    jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_THREAD_END, NULL);
-
+    setActive(false);
     destroyForAllThreads();
 }
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -289,7 +289,6 @@ int PerfEvents::_max_events = 0;
 PerfEvent* PerfEvents::_events = NULL;
 PerfEventType* PerfEvents::_event_type = NULL;
 long PerfEvents::_interval;
-bool PerfEvents::_is_active = false;
 
 int PerfEvents::tid() {
     return syscall(__NR_gettid);
@@ -449,12 +448,10 @@ Error PerfEvents::start(const char* event, long interval) {
     if (!createForAllThreads()) {
         return Error("Perf events unavailble. See stderr of the target process.");
     }
-    setActive(true);
     return Error::OK;
 }
 
 void PerfEvents::stop() {
-    setActive(false);
     destroyForAllThreads();
 }
 

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -28,7 +28,6 @@ int PerfEvents::_max_events;
 PerfEvent* PerfEvents::_events;
 PerfEventType* PerfEvents::_event_type;
 long PerfEvents::_interval;
-bool PerfEvents::_is_active = false;
 
 int PerfEvents::tid() {
     return pthread_mach_thread_np(pthread_self());
@@ -71,12 +70,10 @@ Error PerfEvents::start(const char* event, long interval) {
     struct itimerval tv = {{sec, usec}, {sec, usec}};
     setitimer(ITIMER_PROF, &tv, NULL);
 
-    setActive(true);
     return Error::OK;
 }
 
 void PerfEvents::stop() {
-    setActive(false);
     struct itimerval tv = {{0, 0}, {0, 0}};
     setitimer(ITIMER_PROF, &tv, NULL);
 }

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -28,7 +28,7 @@ int PerfEvents::_max_events;
 PerfEvent* PerfEvents::_events;
 PerfEventType* PerfEvents::_event_type;
 long PerfEvents::_interval;
-
+bool PerfEvents::_is_active = false;
 
 int PerfEvents::tid() {
     return pthread_mach_thread_np(pthread_self());
@@ -71,10 +71,12 @@ Error PerfEvents::start(const char* event, long interval) {
     struct itimerval tv = {{sec, usec}, {sec, usec}};
     setitimer(ITIMER_PROF, &tv, NULL);
 
+    setActive(true);
     return Error::OK;
 }
 
 void PerfEvents::stop() {
+    setActive(false);
     struct itimerval tv = {{0, 0}, {0, 0}};
     setitimer(ITIMER_PROF, &tv, NULL);
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -390,6 +390,8 @@ void Profiler::initJvmtiFunctions() {
                 _JvmtiEnv_GetStackTrace = (jvmtiError (*)(void*, void*, jint, jint, jvmtiFrameInfo*, jint*))
                     libjvm->findSymbol("_ZN8JvmtiEnv13GetStackTraceEP10JavaThreadiiP15_jvmtiFrameInfoPi");
             }
+            // Optional: we need this to extract JVM thread names in addition to ids
+            VMStructs::init(libjvm);
         }
 
         if (_JvmtiEnv_GetStackTrace == NULL) {

--- a/src/threadNames.cpp
+++ b/src/threadNames.cpp
@@ -1,0 +1,48 @@
+#include "threadNames.h"
+#include "profiler.h"
+
+ThreadNames ThreadNames::_instance;
+
+void ThreadNames::update(jthread thread) {
+    MutexLocker ml(_lock);
+    if (!VMThread::available()) {
+        return;
+    }
+    JNIEnv *env = VM::jni();
+    if (_eetop == NULL) {
+        _threadClass = env->FindClass("java/lang/Thread");
+        if (_threadClass == NULL) {
+            return;
+        }
+        _eetop = env->GetFieldID(_threadClass, "eetop", "J");
+        if (_eetop == NULL) {
+            return;
+        }
+    }
+    VMThread *vm_thread = (VMThread *)(uintptr_t)env->GetLongField(thread, _eetop);
+    jvmtiThreadInfo info;
+    jvmtiEnv *jvmti = VM::jvmti();
+    if (jvmti->GetThreadInfo(thread, &info) != 0 || info.name == NULL) {
+        return;
+    }
+    _storage[vm_thread->osThreadId()] = std::string(info.name);
+    jvmti->Deallocate((unsigned char *)info.name);
+}
+
+NamesMap ThreadNames::getNames() {
+    MutexLocker ml(_lock);
+    std::map<int, std::string> result = _storage;
+    return result;
+}
+
+void updateAllKnownThreads() {
+    jvmtiEnv *jvmti = VM::jvmti();
+    jthread *thread_objects;
+    int _thread_count;
+    if (jvmti->GetAllThreads(&_thread_count, &thread_objects) != 0) {
+        return;
+    }
+    for (int i = 0; i < _thread_count; i++) {
+        ThreadNames::_instance.update(thread_objects[i]);
+    }
+}

--- a/src/threadNames.cpp
+++ b/src/threadNames.cpp
@@ -1,48 +1,52 @@
 #include "threadNames.h"
 #include "profiler.h"
 
-ThreadNames ThreadNames::_instance;
+
+jfieldID ThreadNames::_get_eetop(JNIEnv *env) {
+    MutexLocker ml(_cached_eetop_lock);
+    if (_cached_eetop == NULL) {
+        jclass threadClass = env->FindClass("java/lang/Thread");
+        if (threadClass != NULL) {
+            _cached_eetop = env->GetFieldID(threadClass, "eetop", "J");
+        }
+    }
+    return _cached_eetop;
+}
 
 void ThreadNames::update(jthread thread) {
-    MutexLocker ml(_lock);
     if (!VMThread::available()) {
         return;
     }
     JNIEnv *env = VM::jni();
-    if (_eetop == NULL) {
-        _threadClass = env->FindClass("java/lang/Thread");
-        if (_threadClass == NULL) {
-            return;
-        }
-        _eetop = env->GetFieldID(_threadClass, "eetop", "J");
-        if (_eetop == NULL) {
-            return;
-        }
+    jfieldID eetop = _get_eetop(env);
+    if (eetop == NULL) {
+        return;
     }
-    VMThread *vm_thread = (VMThread *)(uintptr_t)env->GetLongField(thread, _eetop);
+    VMThread *vm_thread = (VMThread *)(uintptr_t)env->GetLongField(thread, eetop);
     jvmtiThreadInfo info;
     jvmtiEnv *jvmti = VM::jvmti();
     if (jvmti->GetThreadInfo(thread, &info) != 0 || info.name == NULL) {
         return;
     }
+    MutexLocker ml(_storage_lock);
     _storage[vm_thread->osThreadId()] = std::string(info.name);
     jvmti->Deallocate((unsigned char *)info.name);
 }
 
-NamesMap ThreadNames::getNames() {
-    MutexLocker ml(_lock);
-    std::map<int, std::string> result = _storage;
-    return result;
-}
-
-void updateAllKnownThreads() {
+void ThreadNames::updateAllKnownThreads() {
     jvmtiEnv *jvmti = VM::jvmti();
     jthread *thread_objects;
-    int _thread_count;
-    if (jvmti->GetAllThreads(&_thread_count, &thread_objects) != 0) {
+    int thread_count;
+    if (jvmti->GetAllThreads(&thread_count, &thread_objects) != 0) {
         return;
     }
-    for (int i = 0; i < _thread_count; i++) {
-        ThreadNames::_instance.update(thread_objects[i]);
+    for (int i = 0; i < thread_count; i++) {
+        update(thread_objects[i]);
     }
+}
+
+NamesMap ThreadNames::getNames() {
+    MutexLocker ml(_storage_lock);
+    NamesMap result = _storage;
+    return result;
 }

--- a/src/threadNames.h
+++ b/src/threadNames.h
@@ -7,27 +7,30 @@
 #include <string>
 #include "vmStructs.h"
 #include "vmEntry.h"
+#include "concurrencyUtil.h"
 
 
 typedef std::map<int, std::string> NamesMap;
 
 class ThreadNames {
   private:
-    pthread_mutex_t _lock;
     NamesMap _storage;
-    jclass _threadClass;
-    jfieldID _eetop;
-  public:
-    static ThreadNames _instance;
+    pthread_mutex_t _storage_lock;
+    jfieldID _cached_eetop;
+    pthread_mutex_t _cached_eetop_lock;
+    jfieldID _get_eetop(JNIEnv *env);
 
+  public:
     ThreadNames() :
-        _threadClass(NULL),
-        _eetop(NULL) {}
+        _cached_eetop(NULL) {
+        initLock(&_storage_lock);
+        initLock(&_cached_eetop_lock);
+    }
 
     void update(jthread thread);
+    void updateAllKnownThreads();
     NamesMap getNames();
 };
 
-void updateAllKnownThreads();
 
 #endif //_THREADNAME_H

--- a/src/threadNames.h
+++ b/src/threadNames.h
@@ -4,6 +4,7 @@
 #include <jvmti.h>
 #include <pthread.h>
 #include <map>
+#include <string>
 #include "vmStructs.h"
 #include "vmEntry.h"
 

--- a/src/threadNames.h
+++ b/src/threadNames.h
@@ -1,0 +1,32 @@
+#ifndef _THREADNAME_H
+#define _THREADNAME_H
+
+#include <jvmti.h>
+#include <pthread.h>
+#include <map>
+#include "vmStructs.h"
+#include "vmEntry.h"
+
+
+typedef std::map<int, std::string> NamesMap;
+
+class ThreadNames {
+  private:
+    pthread_mutex_t _lock;
+    NamesMap _storage;
+    jclass _threadClass;
+    jfieldID _eetop;
+  public:
+    static ThreadNames _instance;
+
+    ThreadNames() :
+        _threadClass(NULL),
+        _eetop(NULL) {}
+
+    void update(jthread thread);
+    NamesMap getNames();
+};
+
+void updateAllKnownThreads();
+
+#endif //_THREADNAME_H

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -74,6 +74,9 @@ class VM {
     static void JNICALL ClassPrepare(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jclass klass) {
         loadMethodIDs(jvmti, klass);
     }
+
+    static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
+    static void JNICALL ThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
 };
 
 #endif // _VMENTRY_H

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -74,9 +74,6 @@ class VM {
     static void JNICALL ClassPrepare(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, jclass klass) {
         loadMethodIDs(jvmti, klass);
     }
-
-    static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
-    static void JNICALL ThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
 };
 
 #endif // _VMENTRY_H

--- a/test/ThreadsTarget.java
+++ b/test/ThreadsTarget.java
@@ -1,9 +1,17 @@
 public class ThreadsTarget {
     public static void main(String[] args) {
-        new Thread(ThreadsTarget::methodForThreadEarlyEnd, "ThreadEarlyEnd").start();
-        new Thread(() -> {
-            Thread.currentThread().setName("RenamedThread");
-            methodForRenamedThread();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                methodForThreadEarlyEnd();
+            }
+        }, "ThreadEarlyEnd").start();
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                Thread.currentThread().setName("RenamedThread");
+                methodForRenamedThread();
+            }
         }, "ThreadWillBeRenamed").start();
     }
 

--- a/test/ThreadsTarget.java
+++ b/test/ThreadsTarget.java
@@ -1,0 +1,25 @@
+public class ThreadsTarget {
+    public static void main(String[] args) {
+        new Thread(ThreadsTarget::methodForThreadEarlyEnd, "ThreadEarlyEnd").start();
+        new Thread(() -> {
+            Thread.currentThread().setName("RenamedThread");
+            methodForRenamedThread();
+        }, "ThreadWillBeRenamed").start();
+    }
+
+    static void methodForThreadEarlyEnd() {
+        long now = System.currentTimeMillis();
+        long counter = 0;
+        while (System.currentTimeMillis() - now < 300) {
+            counter++;
+        }
+    }
+
+    static void methodForRenamedThread() {
+        long now = System.currentTimeMillis();
+        long counter = 0;
+        while (System.currentTimeMillis() - now < 1000) {
+            counter++;
+        }
+    }
+}

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -31,6 +31,6 @@ fi
     fi
   }
 
-  assert_string "AllocThread-1;.*AllocatingTarget.allocate;.*java.lang.Integer\[\]"
-  assert_string "AllocThread-2;.*AllocatingTarget.allocate;.*int\[\]"
+  assert_string "\[AllocThread-1 tid=[0-9]\+\];.*AllocatingTarget.allocate;.*java.lang.Integer\[\]"
+  assert_string "\[AllocThread-2 tid=[0-9]\+\];.*AllocatingTarget.allocate;.*int\[\]"
 )

--- a/test/thread-smoke-test.sh
+++ b/test/thread-smoke-test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e  # exit on any failure
+set -x  # print all executed lines
+
+if [ -z "${JAVA_HOME}" ]; then
+  echo "JAVA_HOME is not set"
+  exit 1
+fi
+
+(
+  cd $(dirname $0)
+
+  if [ "ThreadsTarget.class" -ot "ThreadsTarget.java" ]; then
+     ${JAVA_HOME}/bin/javac ThreadsTarget.java
+  fi
+
+  FILENAME=/tmp/java.trace
+
+  ${JAVA_HOME}/bin/java -agentpath:../build/libasyncProfiler.so=start,collapsed,threads,file=$FILENAME ThreadsTarget
+
+  # wait for normal termination
+
+  function assert_string() {
+    if ! grep -q "$1" $FILENAME; then
+      exit 1
+    fi
+  }
+
+  assert_string "\[ThreadEarlyEnd tid=[0-9]\+\];.*ThreadsTarget.methodForThreadEarlyEnd;.*"
+  assert_string "\[RenamedThread tid=[0-9]\+\];.*ThreadsTarget.methodForRenamedThread;.*"
+)


### PR DESCRIPTION
This PR brings better JVM thread names reporting.
- VMStructs symbols are loaded at the same time when AGCT symbols do: it fix bug when no thread names was reported by perf engine.
- Thread names storage is updated on every thread start and thread end: we can get names not only for active at the moment of dump threads , but also for all threads that had already stopped.
- I slightly changed thread output format to `[<thread Name> tid=<thread id>]`, because we need to distinguish different threads with the same name and to understand if dump contains thread labels or not.