### PR TITLE
Use absolute path for output file

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -204,6 +204,10 @@ if [[ "$OUTPUT" == "" ]]; then
     fi
 fi
 
+# using absolute path name is required
+# otherwise if -f argument value is relative we don't generate expected output file
+FILE=$(abspath ${FILE})
+
 case $ACTION in
     start)
         jattach "start,event=$EVENT,file=$FILE$INTERVAL$JSTACKDEPTH$FRAMEBUF$THREADS,$OUTPUT$FORMAT"


### PR DESCRIPTION
If we parameters as described in documentation, we don't get the expected output file.
Using an absolute path seems to be required to behave as expected.