### PR TITLE
improve profiler.sh for work with symlink

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -86,7 +86,7 @@ function abspath() {
 
 
 OPTIND=1
-SCRIPT_DIR=$(dirname $0)
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
 JATTACH=$SCRIPT_DIR/build/jattach
 PROFILER=$(abspath $SCRIPT_DIR/build/libasyncProfiler.so)
 ACTION="collect"


### PR DESCRIPTION
Hi! I use your profiler with `update-alternatives` and now when I try to connect to process I get something like 
```
/my/path/to/symlink/build/jattach: No such file
```

this fix works for me and work with usual usage as well.