### PR TITLE
fix thread names format

### DIFF
--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -211,10 +211,10 @@ const char* FrameName::name(ASGCT_CallFrame& frame) {
             int tid = (int)(uintptr_t)frame.method_id;
             const char* name = findThreadName(tid);
             if (name != NULL) {
-                return name;
+                snprintf(_buf, sizeof(_buf), "[%s tid=%d]", name, tid);
+            } else {
+                snprintf(_buf, sizeof(_buf), "[tid=%d]", tid);
             }
-
-            snprintf(_buf, sizeof(_buf), "[thread %d]", tid);
             return _buf;
         }
 

--- a/test/alloc-smoke-test.sh
+++ b/test/alloc-smoke-test.sh
@@ -31,6 +31,6 @@ fi
     fi
   }
 
-  assert_string "AllocThread-1;.*AllocatingTarget.allocate;.*java.lang.Integer\[\]"
-  assert_string "AllocThread-2;.*AllocatingTarget.allocate;.*int\[\]"
+  assert_string "\[AllocThread-1 tid=[0-9]\+\];.*AllocatingTarget.allocate;.*java.lang.Integer\[\]"
+  assert_string "\[AllocThread-2 tid=[0-9]\+\];.*AllocatingTarget.allocate;.*int\[\]"
 )


### PR DESCRIPTION
In our inner fork we use '[' and ']' to understand that thread dump has named threads(if first frame starts with '[' and ends with ']' and it isn't  `[unknown]` it should be thread name)
And when users decide to use upstream version they have funny bugs, like this: https://youtrack.jetbrains.com/issue/IDEA-200453
I also add thread id information for JVM threads do distinguish different threads with same name and to match profiler info to other collected thread related data, if any.