### PR TITLE
fix compilation for macos 10.8.5

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -33,7 +33,17 @@
 #define ARRAY_SIZE(arr)  (sizeof(arr) / sizeof(arr[0]))
 
 #ifndef htonll
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+#define bswap_64(x) OSSwapInt64(x)
+
+#else
+
 #include <byteswap.h>
+
+#endif // __APPLE__
 
 static inline u64 htonll(u64 x) {
     return htonl(1) == 1 ? x : bswap_64(x);


### PR DESCRIPTION
IntelliJ IDEA supports macs 10.8.5+ so we need to compile agent library on very old build agents.
This small change fix compilation for us.