### PR TITLE
Wall-clock profiling

### DIFF
--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -17,6 +17,7 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include "allocTracer.h"
+#include "os.h"
 #include "profiler.h"
 #include "stackFrame.h"
 #include "vmStructs.h"
@@ -65,16 +66,6 @@ void Trap::uninstall() {
     }
 }
 
-
-void AllocTracer::installSignalHandler() {
-    struct sigaction sa;
-    sigemptyset(&sa.sa_mask);
-    sa.sa_handler = NULL;
-    sa.sa_sigaction = signalHandler;
-    sa.sa_flags = SA_RESTART | SA_SIGINFO;
-
-    sigaction(SIGTRAP, &sa, NULL);
-}
 
 // Called whenever our breakpoint trap is hit
 void AllocTracer::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
@@ -127,7 +118,7 @@ Error AllocTracer::start(const char* event, long interval) {
         return Error("No AllocTracer symbols found. Are JDK debug symbols installed?");
     }
 
-    installSignalHandler();
+    OS::installSignalHandler(SIGTRAP, signalHandler);
 
     _in_new_tlab.install();
     _outside_tlab.install();

--- a/src/allocTracer.h
+++ b/src/allocTracer.h
@@ -52,7 +52,6 @@ class AllocTracer : public Engine {
     static Trap _in_new_tlab2;
     static Trap _outside_tlab2;
 
-    static void installSignalHandler();
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void recordAllocation(void* ucontext, uintptr_t rklass, uintptr_t rsize, bool outside_tlab); 
 

--- a/src/allocTracer.h
+++ b/src/allocTracer.h
@@ -60,6 +60,10 @@ class AllocTracer : public Engine {
         return "alloc";
     }
 
+    const char* units() {
+        return "bytes";
+    }
+
     Error start(Arguments& args);
     void stop();
 };

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -26,6 +26,7 @@ const int DEFAULT_FRAMEBUF = 1000000;
 const char* const EVENT_CPU   = "cpu";
 const char* const EVENT_ALLOC = "alloc";
 const char* const EVENT_LOCK  = "lock";
+const char* const EVENT_WALL  = "wall";
 
 enum Action {
     ACTION_NONE,

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "engine.h"
+#include "stackFrame.h"
+
+
+int Engine::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
+                           const void* jit_min_address, const void* jit_max_address) {
+    StackFrame frame(ucontext);
+    const void* pc = (const void*)frame.pc();
+    uintptr_t fp = frame.fp();
+    uintptr_t prev_fp = (uintptr_t)&fp;
+
+    int depth = 0;
+    const void* const valid_pc = (const void*)0x1000;
+
+    // Walk until the bottom of the stack or until the first Java frame
+    while (depth < max_depth && pc >= valid_pc && !(pc >= jit_min_address && pc < jit_max_address)) {
+        callchain[depth++] = pc;
+
+        // Check if the next frame is below on the current stack
+        if (fp <= prev_fp || fp >= prev_fp + 0x40000) {
+            break;
+        }
+
+        prev_fp = fp;
+        pc = ((const void**)fp)[1];
+        fp = ((uintptr_t*)fp)[0];
+    }
+
+    return depth;
+}

--- a/src/engine.h
+++ b/src/engine.h
@@ -23,11 +23,13 @@
 class Engine {
   public:
     virtual const char* name() = 0;
+    virtual const char* units() = 0;
 
     virtual Error start(Arguments& args) = 0;
     virtual void stop() = 0;
 
-    virtual ~Engine() {}
+    virtual int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
+                               const void* jit_min_address, const void* jit_max_address);
 };
 
 #endif // _ENGINE_H

--- a/src/lockTracer.h
+++ b/src/lockTracer.h
@@ -39,6 +39,10 @@ class LockTracer : public Engine {
         return "lock";
     }
 
+    const char* units() {
+        return "ns";
+    }
+
     Error start(Arguments& args);
     void stop();
 

--- a/src/os.h
+++ b/src/os.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _OS_H
+#define _OS_H
+
+#include <signal.h>
+
+
+class ThreadList {
+  public:
+    virtual ~ThreadList() {}
+    virtual int next() = 0;
+};
+
+
+class OS {
+  public:
+    static int threadId();
+    static void installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*));
+    static void sendSignalToThread(int thread_id, int signo);
+    static ThreadList* listThreads();
+};
+
+#endif // _OS_H

--- a/src/os.h
+++ b/src/os.h
@@ -18,6 +18,7 @@
 #define _OS_H
 
 #include <signal.h>
+#include "arch.h"
 
 
 class ThreadList {
@@ -29,6 +30,9 @@ class ThreadList {
 
 class OS {
   public:
+    static u64 nanotime();
+    static u64 millis();
+    static u64 hton64(u64 x);
     static int threadId();
     static void installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*));
     static void sendSignalToThread(int thread_id, int signo);

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __linux__
+
+#include <dirent.h>
+#include <stdlib.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "os.h"
+
+
+class LinuxThreadList : public ThreadList {
+  private:
+    DIR* _dir;
+
+  public:
+    LinuxThreadList() {
+        _dir = opendir("/proc/self/task");
+    }
+
+    ~LinuxThreadList() {
+        if (_dir != NULL) {
+            closedir(_dir);
+        }
+    }
+
+    int next() {
+        if (_dir != NULL) {
+            struct dirent* entry;
+            while ((entry = readdir(_dir)) != NULL) {
+                if (entry->d_name[0] != '.') {
+                    return atoi(entry->d_name);
+                }
+            }
+        }
+        return -1;
+    }
+};
+
+
+int OS::threadId() {
+    return syscall(__NR_gettid);
+}
+
+void OS::installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*)) {
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = NULL;
+    sa.sa_sigaction = handler;
+    sa.sa_flags = SA_RESTART | SA_SIGINFO;
+
+    sigaction(signo, &sa, NULL);
+}
+
+void OS::sendSignalToThread(int thread_id, int signo) {
+    static const int self_pid = getpid();
+
+    syscall(__NR_tgkill, self_pid, thread_id, signo);
+}
+
+ThreadList* OS::listThreads() {
+    return new LinuxThreadList();
+}
+
+#endif // __linux__

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -16,10 +16,14 @@
 
 #ifdef __linux__
 
+#include <arpa/inet.h>
+#include <byteswap.h>
 #include <dirent.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
+#include <sys/time.h>
 #include <sys/types.h>
+#include <time.h>
 #include <unistd.h>
 #include "os.h"
 
@@ -52,6 +56,22 @@ class LinuxThreadList : public ThreadList {
     }
 };
 
+
+u64 OS::nanotime() {
+    struct timespec tp;
+    clock_gettime(CLOCK_MONOTONIC, &tp);
+    return (u64)tp.tv_sec * 1000000000 + tp.tv_nsec;
+}
+
+u64 OS::millis() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (u64)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+u64 OS::hton64(u64 x) {
+    return htonl(1) == 1 ? x : bswap_64(x);
+}
 
 int OS::threadId() {
     return syscall(__NR_gettid);

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -16,9 +16,12 @@
 
 #ifdef __APPLE__
 
+#include <libkern/OSByteOrder.h>
 #include <mach/mach_init.h>
 #include <mach/mach_interface.h>
+#include <mach/mach_time.h>
 #include <pthread.h>
+#include <sys/time.h>
 #include "os.h"
 
 
@@ -45,6 +48,25 @@ class MacThreadList : public ThreadList {
     }
 };
 
+
+static mach_timebase_info_data_t timebase = {0, 0};
+
+u64 OS::nanotime() {
+    if (timebase.denom == 0) {
+        mach_timebase_info(&timebase);
+    }
+    return (u64)mach_absolute_time() * timebase.numer / timebase.denom;
+}
+
+u64 OS::millis() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    return (u64)tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+u64 OS::hton64(u64 x) {
+    return OSSwapHostToBigInt64(x);
+}
 
 int OS::threadId() {
     return pthread_mach_thread_np(pthread_self());

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef __APPLE__
+
+#include <mach/mach_init.h>
+#include <mach/mach_interface.h>
+#include <pthread.h>
+#include "os.h"
+
+
+class MacThreadList : public ThreadList {
+  private:
+    thread_array_t _thread_array;
+    unsigned int _thread_count;
+    unsigned int _thread_index;
+
+  public:
+    MacThreadList() : _thread_array(NULL), _thread_count(0), _thread_index(0) {
+        task_threads(mach_task_self(), &_thread_array, &_thread_count);
+    }
+
+    ~MacThreadList() {
+        vm_deallocate(mach_task_self(), (vm_address_t)_thread_array, sizeof(thread_t) * _thread_count);
+    }
+
+    int next() {
+        if (_thread_index < _thread_count) {
+            return (int)_thread_array[_thread_index++];
+        }
+        return -1;
+    }
+};
+
+
+int OS::threadId() {
+    return pthread_mach_thread_np(pthread_self());
+}
+
+void OS::installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*)) {
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = NULL;
+    sa.sa_sigaction = handler;
+    sa.sa_flags = SA_RESTART | SA_SIGINFO;
+
+    sigaction(signo, &sa, NULL);
+}
+
+void OS::sendSignalToThread(int thread_id, int signo) {
+   asm volatile("syscall" : : "a"(0x2000148), "D"(thread_id), "S"(signo));
+}
+
+ThreadList* OS::listThreads() {
+    return new MacThreadList();
+}
+
+#endif // __APPLE__

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -20,6 +20,7 @@
 #include <jvmti.h>
 #include <signal.h>
 #include "engine.h"
+#include "os.h"
 
 
 class PerfEvent;
@@ -36,7 +37,6 @@ class PerfEvents : public Engine {
     static bool createForAllThreads();
     static void destroyForThread(int tid);
     static void destroyForAllThreads();
-    static void installSignalHandler();
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 
   public:
@@ -47,17 +47,16 @@ class PerfEvents : public Engine {
     Error start(const char* event, long interval);
     void stop();
 
-    static int tid();
     static const char** getAvailableEvents();
     static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
                             const void* jit_min_address, const void* jit_max_address);
 
     static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
-        createForThread(tid());
+        createForThread(OS::threadId());
     }
 
     static void JNICALL ThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
-        destroyForThread(tid());
+        destroyForThread(OS::threadId());
     }
 };
 

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -46,12 +46,15 @@ class PerfEvents : public Engine {
         return "perf";
     }
 
+    const char* units();
+
     Error start(Arguments& args);
     void stop();
 
+    int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
+                       const void* jit_min_address, const void* jit_max_address);
+
     static const char** getAvailableEvents();
-    static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
-                            const void* jit_min_address, const void* jit_max_address);
 
     static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
         createForThread(OS::threadId());

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -29,6 +29,7 @@
 #include "flameGraph.h"
 #include "flightRecorder.h"
 #include "frameName.h"
+#include "os.h"
 #include "stackFrame.h"
 #include "symbols.h"
 
@@ -334,7 +335,7 @@ void Profiler::recordSample(void* ucontext, u64 counter, jint event_type, jmetho
     atomicInc(_total_counter, counter);
 
     ASGCT_CallFrame* frames = _calltrace_buffer[lock_index]._asgct_frames;
-    int tid = PerfEvents::tid();
+    int tid = OS::threadId();
 
     int num_frames;
     if (event == NULL) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -25,6 +25,7 @@
 #include "perfEvents.h"
 #include "allocTracer.h"
 #include "lockTracer.h"
+#include "wallClock.h"
 #include "flameGraph.h"
 #include "flightRecorder.h"
 #include "frameName.h"
@@ -182,8 +183,8 @@ const char* Profiler::findNativeMethod(const void* address) {
 
 int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, int tid) {
     const void* native_callchain[MAX_NATIVE_FRAMES];
-    int native_frames = PerfEvents::getCallChain(ucontext, tid, native_callchain, MAX_NATIVE_FRAMES,
-                                                 _jit_min_address, _jit_max_address);
+    int native_frames = WallClock::getCallChain(ucontext, tid, native_callchain, MAX_NATIVE_FRAMES,
+                                                _jit_min_address, _jit_max_address);
 
     for (int i = 0; i < native_frames; i++) {
         frames[i].bci = BCI_NATIVE_FRAME;
@@ -445,6 +446,9 @@ Error Profiler::start(Arguments& args) {
         _units = "bytes";
     } else if (strcmp(args._event, EVENT_LOCK) == 0) {
         _engine = new LockTracer();
+        _units = "ns";
+    } else if (strcmp(args._event, EVENT_WALL) == 0) {
+        _engine = new WallClock();
         _units = "ns";
     } else {
         _engine = new PerfEvents();

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -195,7 +195,7 @@ const char* Profiler::findNativeMethod(const void* address) {
 
 int Profiler::getNativeTrace(void* ucontext, ASGCT_CallFrame* frames, int tid) {
     const void* native_callchain[MAX_NATIVE_FRAMES];
-    int native_frames = WallClock::getCallChain(ucontext, tid, native_callchain, MAX_NATIVE_FRAMES,
+    int native_frames = _engine->getNativeTrace(ucontext, tid, native_callchain, MAX_NATIVE_FRAMES,
                                                 _jit_min_address, _jit_max_address);
 
     for (int i = 0; i < native_frames; i++) {
@@ -411,6 +411,25 @@ void Profiler::initJvmtiFunctions(NativeCodeCache* libjvm) {
     }
 }
 
+Engine* Profiler::selectEngine(const char* event_name) {
+    static Engine* PERF_EVENTS = new PerfEvents();
+    static Engine* ALLOC_TRACER = new AllocTracer();
+    static Engine* LOCK_TRACER = new LockTracer();
+    static Engine* WALL_CLOCK = new WallClock();
+
+    if (strcmp(event_name, EVENT_CPU) == 0) {
+        return PERF_EVENTS;
+    } else if (strcmp(event_name, EVENT_ALLOC) == 0) {
+        return ALLOC_TRACER;
+    } else if (strcmp(event_name, EVENT_LOCK) == 0) {
+        return LOCK_TRACER;
+    } else if (strcmp(event_name, EVENT_WALL) == 0) {
+        return WALL_CLOCK;
+    } else {
+        return PERF_EVENTS;
+    }
+}
+
 Error Profiler::start(Arguments& args) {
     MutexLocker ml(_state_lock);
     if (_state != IDLE) {
@@ -455,26 +474,9 @@ Error Profiler::start(Arguments& args) {
         }
     }
 
-    if (strcmp(args._event, EVENT_CPU) == 0) {
-        _engine = new PerfEvents();
-        _units = "ns";
-    } else if (strcmp(args._event, EVENT_ALLOC) == 0) {
-        _engine = new AllocTracer();
-        _units = "bytes";
-    } else if (strcmp(args._event, EVENT_LOCK) == 0) {
-        _engine = new LockTracer();
-        _units = "ns";
-    } else if (strcmp(args._event, EVENT_WALL) == 0) {
-        _engine = new WallClock();
-        _units = "ns";
-    } else {
-        _engine = new PerfEvents();
-        _units = "events";
-    }
-
+    _engine = selectEngine(args._event);
     Error error = _engine->start(args);
     if (error) {
-        delete _engine;
         _jfr.stop();
         return error;
     }
@@ -491,7 +493,6 @@ Error Profiler::stop() {
     }
 
     _engine->stop();
-    delete _engine;
 
     // Acquire all spinlocks to avoid race with remaining signals
     for (int i = 0; i < CONCURRENCY_LEVEL; i++) _locks[i].lock();
@@ -550,7 +551,7 @@ void Profiler::dumpSummary(std::ostream& out) {
  */
 void Profiler::dumpCollapsed(std::ostream& out, Arguments& args) {
     MutexLocker ml(_state_lock);
-    if (_state != IDLE) return;
+    if (_state != IDLE || _engine == NULL) return;
 
     FrameName fn(args._simple, false, _threads);
     u64 unknown = 0;
@@ -578,7 +579,7 @@ void Profiler::dumpCollapsed(std::ostream& out, Arguments& args) {
 
 void Profiler::dumpFlameGraph(std::ostream& out, Arguments& args, bool tree) {
     MutexLocker ml(_state_lock);
-    if (_state != IDLE) return;
+    if (_state != IDLE || _engine == NULL) return;
 
     FlameGraph flamegraph(args._title, args._counter, args._width, args._height, args._minwidth, args._reverse);
     FrameName fn(args._simple, false, _threads);
@@ -611,7 +612,7 @@ void Profiler::dumpFlameGraph(std::ostream& out, Arguments& args, bool tree) {
 
 void Profiler::dumpTraces(std::ostream& out, int max_traces) {
     MutexLocker ml(_state_lock);
-    if (_state != IDLE) return;
+    if (_state != IDLE || _engine == NULL) return;
 
     FrameName fn(false, true, _threads);
     double percent = 100.0 / _total_counter;
@@ -625,7 +626,7 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
         if (trace._samples == 0) break;
 
         snprintf(buf, sizeof(buf), "--- %lld %s (%.2f%%), %lld sample%s\n",
-                 trace._counter, _units, trace._counter * percent,
+                 trace._counter, _engine->units(), trace._counter * percent,
                  trace._samples, trace._samples == 1 ? "" : "s");
         out << buf;
 
@@ -644,7 +645,7 @@ void Profiler::dumpTraces(std::ostream& out, int max_traces) {
 
 void Profiler::dumpFlat(std::ostream& out, int max_methods) {
     MutexLocker ml(_state_lock);
-    if (_state != IDLE) return;
+    if (_state != IDLE || _engine == NULL) return;
 
     FrameName fn(false, true, _threads);
     double percent = 100.0 / _total_counter;
@@ -654,7 +655,7 @@ void Profiler::dumpFlat(std::ostream& out, int max_methods) {
     if (max_methods > MAX_CALLTRACES) max_methods = MAX_CALLTRACES;
 
     snprintf(buf, sizeof(buf), "%12s  percent  samples  top\n"
-                               "  ----------  -------  -------  ---\n", _units);
+                               "  ----------  -------  -------  ---\n", _engine->units());
     out << buf;
 
     for (int i = 0; i < max_methods; i++) {
@@ -708,6 +709,7 @@ void Profiler::runInternal(Arguments& args, std::ostream& out) {
             out << "Java events:" << std::endl;
             out << "  " << EVENT_ALLOC << std::endl;
             out << "  " << EVENT_LOCK << std::endl;
+            out << "  " << EVENT_WALL << std::endl;
             break;
         }
         case ACTION_VERSION:

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -127,7 +127,6 @@ class Profiler {
     State _state;
     FlightRecorder _jfr;
     Engine* _engine;
-    const char* _units;
     time_t _start_time;
 
     u64 _total_samples;
@@ -178,7 +177,7 @@ class Profiler {
     void initStateLock();
     void resetSymbols();
     void initJvmtiFunctions(NativeCodeCache* libjvm);
-    void setSignalHandler();
+    Engine* selectEngine(const char* event_name);
 
   public:
     static Profiler _instance;
@@ -186,7 +185,6 @@ class Profiler {
     Profiler() :
         _state(IDLE),
         _jfr(),
-        _units("events"),
         _frame_buffer(NULL),
         _jit_lock(),
         _jit_min_address((const void*)-1),

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <string.h>
+#include <stdlib.h>
+#include <signal.h>
+#include <poll.h>
+#include <dirent.h>
+#include <sys/eventfd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "wallClock.h"
+#include "profiler.h"
+#include "stackFrame.h"
+
+
+const int THREADS_PER_TICK = 5;
+
+long WallClock::_interval;
+
+void WallClock::installSignalHandler() {
+    struct sigaction sa;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_handler = NULL;
+    sa.sa_sigaction = signalHandler;
+    sa.sa_flags = SA_RESTART | SA_SIGINFO;
+
+    sigaction(SIGPROF, &sa, NULL);
+}
+
+void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
+    Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
+}
+
+Error WallClock::start(const char* event, long interval) {
+    if (interval < 0) {
+        return Error("interval must be positive");
+    }
+    _interval = interval ? interval : DEFAULT_INTERVAL;
+
+    installSignalHandler();
+
+    _pid = getpid();
+    _eventfd = eventfd(0, 0);
+    if (_eventfd == -1) {
+        return Error("Unable to create timer event");
+    }
+
+    if (pthread_create(&_thread, NULL, threadEntry, this) != 0) {
+        close(_eventfd);
+        return Error("Unable to create timer thread");
+    }
+
+    return Error::OK;
+}
+
+void WallClock::stop() {
+    u64 val = 1;
+    ssize_t r = write(_eventfd, &val, sizeof(val));
+    (void)r;
+
+    pthread_join(_thread, NULL);
+}
+
+void WallClock::timerLoop() {
+    DIR* dir = NULL;
+
+    struct timespec ts = {_interval / 1000000000, _interval % 1000000000};
+    struct pollfd fds = {_eventfd, POLLIN, 0};
+
+    while (ppoll(&fds, 1, &ts, NULL) == 0) {
+        if (dir == NULL && (dir = opendir("/proc/self/task")) == NULL) {
+            return;
+        }
+
+        for (int thread_count = 0; thread_count < THREADS_PER_TICK; ) {
+            struct dirent* entry = readdir(dir);
+            if (entry == NULL) {
+                closedir(dir);
+                dir = NULL;
+                break;
+            }
+
+            if (entry->d_name[0] != '.') {
+                int tid = atoi(entry->d_name);
+                syscall(__NR_tgkill, _pid, tid, SIGPROF);
+                thread_count++;
+            }
+        }
+    }
+
+    if (dir != NULL) {
+        closedir(dir);
+    }
+}
+
+int WallClock::getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
+                            const void* jit_min_address, const void* jit_max_address) {
+    StackFrame frame(ucontext);
+    const void* pc = (const void*)frame.pc();
+    uintptr_t fp = frame.fp();
+    uintptr_t prev_fp = (uintptr_t)&fp;
+
+    int depth = 0;
+    const void* const valid_pc = (const void*)0x1000;
+
+    // Walk until the bottom of the stack or until the first Java frame
+    while (depth < max_depth && pc >= valid_pc && !(pc >= jit_min_address && pc < jit_max_address)) {
+        callchain[depth++] = pc;
+
+        // Check if the next frame is below on the current stack
+        if (fp <= prev_fp || fp >= prev_fp + 0x40000) {
+            break;
+        }
+
+        prev_fp = fp;
+        pc = ((const void**)fp)[1];
+        fp = ((uintptr_t*)fp)[0];
+    }
+
+    return depth;
+}

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -33,11 +33,11 @@ void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
     Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
 }
 
-Error WallClock::start(const char* event, long interval) {
-    if (interval < 0) {
+Error WallClock::start(Arguments& args) {
+    if (args._interval < 0) {
         return Error("interval must be positive");
     }
-    _interval = interval ? interval : DEFAULT_INTERVAL;
+    _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
 
     OS::installSignalHandler(SIGPROF, signalHandler);
 

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -22,7 +22,6 @@
 #include "wallClock.h"
 #include "os.h"
 #include "profiler.h"
-#include "stackFrame.h"
 
 
 const int THREADS_PER_TICK = 7;
@@ -89,31 +88,4 @@ void WallClock::timerLoop() {
     }
 
     delete thread_list;
-}
-
-int WallClock::getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
-                            const void* jit_min_address, const void* jit_max_address) {
-    StackFrame frame(ucontext);
-    const void* pc = (const void*)frame.pc();
-    uintptr_t fp = frame.fp();
-    uintptr_t prev_fp = (uintptr_t)&fp;
-
-    int depth = 0;
-    const void* const valid_pc = (const void*)0x1000;
-
-    // Walk until the bottom of the stack or until the first Java frame
-    while (depth < max_depth && pc >= valid_pc && !(pc >= jit_min_address && pc < jit_max_address)) {
-        callchain[depth++] = pc;
-
-        // Check if the next frame is below on the current stack
-        if (fp <= prev_fp || fp >= prev_fp + 0x40000) {
-            break;
-        }
-
-        prev_fp = fp;
-        pc = ((const void**)fp)[1];
-        fp = ((uintptr_t*)fp)[0];
-    }
-
-    return depth;
 }

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -35,6 +35,7 @@ class WallClock : public Engine {
 
     static void* threadEntry(void* wall_clock) {
         ((WallClock*)wall_clock)->timerLoop();
+        return NULL;
     }
 
     static void installSignalHandler();

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -27,8 +27,7 @@ class WallClock : public Engine {
   private:
     static long _interval;
 
-    int _pid;
-    int _eventfd;
+    int _pipefd[2];
     pthread_t _thread;
 
     void timerLoop();
@@ -38,7 +37,6 @@ class WallClock : public Engine {
         return NULL;
     }
 
-    static void installSignalHandler();
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
 
   public:

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -44,11 +44,12 @@ class WallClock : public Engine {
         return "wall";
     }
 
+    const char* units() {
+        return "ns";
+    }
+
     Error start(Arguments& args);
     void stop();
-
-    static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
-                            const void* jit_min_address, const void* jit_max_address);
 };
 
 #endif // _WALLCLOCK_H

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -44,7 +44,7 @@ class WallClock : public Engine {
         return "wall";
     }
 
-    Error start(const char* event, long interval);
+    Error start(Arguments& args);
     void stop();
 
     static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _WALLCLOCK_H
+#define _WALLCLOCK_H
+
+#include <jvmti.h>
+#include <signal.h>
+#include <pthread.h>
+#include "engine.h"
+
+
+class WallClock : public Engine {
+  private:
+    static long _interval;
+
+    int _pid;
+    int _eventfd;
+    pthread_t _thread;
+
+    void timerLoop();
+
+    static void* threadEntry(void* wall_clock) {
+        ((WallClock*)wall_clock)->timerLoop();
+    }
+
+    static void installSignalHandler();
+    static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
+
+  public:
+    const char* name() {
+        return "wall";
+    }
+
+    Error start(const char* event, long interval);
+    void stop();
+
+    static int getCallChain(void* ucontext, int tid, const void** callchain, int max_depth,
+                            const void* jit_min_address, const void* jit_max_address);
+};
+
+#endif // _WALLCLOCK_H


### PR DESCRIPTION
`-e wall` option that enables fixed-interval timer and samples all threads by sending signals to them