### PR TITLE
Distinguish inlined frames

### DIFF
--- a/src/allocTracer.cpp
+++ b/src/allocTracer.cpp
@@ -35,7 +35,7 @@ volatile u64 AllocTracer::_allocated_bytes;
 
 
 // Resolve the address of the intercepted function
-bool Trap::resolve(NativeCodeCache* libjvm) {
+bool Trap::resolve(NativeLib* libjvm) {
     if (_entry != NULL) {
         return true;
     }
@@ -128,7 +128,7 @@ Error AllocTracer::start(Arguments& args) {
         return Error("VMStructs unavailable. Unsupported JVM?");
     }
 
-    NativeCodeCache* libjvm = Profiler::_instance.jvmLibrary();
+    NativeLib* libjvm = Profiler::_instance.jvmLibrary();
     if (!(_in_new_tlab.resolve(libjvm) || _in_new_tlab2.resolve(libjvm)) ||
         !(_outside_tlab.resolve(libjvm) || _outside_tlab2.resolve(libjvm))) {
         return Error("No AllocTracer symbols found. Are JDK debug symbols installed?");

--- a/src/allocTracer.h
+++ b/src/allocTracer.h
@@ -35,7 +35,7 @@ class Trap {
     Trap(const char* func_name) : _func_name(func_name), _entry(NULL) {
     }
 
-    bool resolve(NativeCodeCache* libjvm);
+    bool resolve(NativeLib* libjvm);
     void install();
     void uninstall();
 

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -17,9 +17,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include "codeCache.h"
+#include "vmEntry.h"
 
-
-void CodeCache::expand() {
+void CodeUnit::expand() {
     CodeBlob* old_blobs = _blobs;
     CodeBlob* new_blobs = new CodeBlob[_capacity * 2];
     memcpy(new_blobs, old_blobs, _capacity * sizeof(CodeBlob));
@@ -28,106 +28,165 @@ void CodeCache::expand() {
     delete[] old_blobs;
 }
 
-void CodeCache::add(const void* start, int length, jmethodID method) {
+CodeBlob *CodeUnit::add(const void* start, int length, bool insert) {
     if (_count >= _capacity) {
         expand();
     }
 
-    _blobs[_count]._start = start;
-    _blobs[_count]._end = (const char*)start + length;
-    _blobs[_count]._method = method;
+    if (!insert || _count == 0 || _blobs[_count - 1].end() <= start) {
+        CodeBlob *blob = _blobs + _count;
+        blob->init(start, length);
+        _count++;
+        return blob;
+    }
+    int ret = binarySearchPosition(start);
+    if (ret >= 0) {
+        return &_blobs[ret];
+    }
+    int pos =  -ret - 1;
+    memmove(_blobs + pos + 1, _blobs + pos, (_count - pos) * sizeof(CodeBlob));
+    CodeBlob *blob = _blobs + pos;
+    blob->init(start, length);
     _count++;
+    return blob;
 }
 
-void CodeCache::remove(const void* start, jmethodID method) {
-    for (int i = 0; i < _count; i++) {
-        if (_blobs[i]._start == start && _blobs[i]._method == method) {
-            _blobs[i]._method = NULL;
-            return;
-        }
+void VmCodeCache::remove(const void* start, jmethodID method) {
+    int pos = binarySearchPosition(start);
+    if (_count > (pos + 1)) {
+      memmove(_blobs + pos, _blobs + (pos + 1), (sizeof(CodeBlob)) * (_count - pos -1)); 
     }
+    _count--;
 }
 
-jmethodID CodeCache::find(const void* address) {
-    for (int i = 0; i < _count; i++) {
-        if (address >= _blobs[i]._start && address < _blobs[i]._end) {
-            return _blobs[i]._method;
-        }
-    }
-    return NULL;
-}
-
-
-NativeCodeCache::NativeCodeCache(const char* name, const void* min_address, const void* max_address) {
+NativeLib::NativeLib(const char* name, const void* min_address, const void* max_address) {
     _name = strdup(name);
     _min_address = min_address;
     _max_address = max_address;
+    _is_kernel = false;
 }
 
-NativeCodeCache::~NativeCodeCache() {
+NativeLib::~NativeLib() {
     for (int i = 0; i < _count; i++) {
-        free(_blobs[i]._method);
+        free(_blobs[i].getName());
     }
     free(_name);
 }
 
-void NativeCodeCache::add(const void* start, int length, const char* name) {
+void NativeLib::add(const void* start, int length, const char* name) {
     char* name_copy = strdup(name);
     // Replace non-printable characters
     for (char* s = name_copy; *s != 0; s++) {
         if (*s < ' ') *s = '?';
     }
-    CodeCache::add(start, length, (jmethodID)name_copy);
+    CodeUnit::add(start, length, false)->setName(name_copy);
+    if (start < _min_address) {
+        _min_address = start;
+    }
+    if ((void*)((char*)start + length) > _max_address) {
+        _max_address = (void*)((char*)start + length);
+    }
 }
 
-void NativeCodeCache::sort() {
+void NativeLib::sort() {
     if (_count == 0) return;
 
     qsort(_blobs, _count, sizeof(CodeBlob), CodeBlob::comparator);
 
-    if (_min_address == NULL) _min_address = _blobs[0]._start;
-    if (_max_address == NULL) _max_address = _blobs[_count - 1]._end;
+    if (_min_address == NULL) _min_address = _blobs[0].start();
+    if (_max_address == NULL) _max_address = _blobs[_count - 1].end();
 }
 
-const char* NativeCodeCache::binarySearch(const void* address) {
+const int CodeUnit::binarySearchPosition(const void* addr) {
+    int low = 0;
+    int high = _count - 1;
+
+    int mid;
+    while (low <= high) {
+        mid = (unsigned int)(low + high) >> 1;
+        if (_blobs[mid].end() <= addr) {
+            low = mid + 1;
+        } else if (_blobs[mid].start() > addr) {
+            high = mid - 1;
+        } else if (_blobs[mid].start() <= addr && _blobs[mid].end() > addr) {
+            return mid;
+        }
+    }
+
+    // Symbols with zero size can be valid functions: e.g. ASM entry points or kernel code
+    if (low > 0 && _blobs[low - 1].start() == _blobs[low - 1].end() && _blobs[low - 1].end() == addr) {
+        return low - 1;
+    }
+
+    return -low - 1;
+}
+
+
+const char* NativeLib::binarySearch(const void* address) {
     int low = 0;
     int high = _count - 1;
 
     while (low <= high) {
         int mid = (unsigned int)(low + high) >> 1;
-        if (_blobs[mid]._end <= address) {
+        if (_blobs[mid].end() <= address) {
             low = mid + 1;
-        } else if (_blobs[mid]._start > address) {
+        } else if (_blobs[mid].start() > address) {
             high = mid - 1;
         } else {
-            return (const char*)_blobs[mid]._method;
+            return _blobs[mid].getName();
         }
     }
 
     // Symbols with zero size can be valid functions: e.g. ASM entry points or kernel code
-    if (low > 0 && _blobs[low - 1]._start == _blobs[low - 1]._end) {
-        return (const char*)_blobs[low - 1]._method;
+    if (low > 0 && _blobs[low - 1].start() == _blobs[low - 1].end()) {
+        return _blobs[low - 1].getName();
     }
-    return _name;
+
+   return _name;
 }
 
-const void* NativeCodeCache::findSymbol(const char* name) {
+const void* NativeLib::findSymbol(const char* name) {
     for (int i = 0; i < _count; i++) {
-        const char* blob_name = (const char*)_blobs[i]._method;
+        const char* blob_name = _blobs[i].getName();
         if (blob_name != NULL && strcmp(blob_name, name) == 0) {
-            return _blobs[i]._start;
+          return _blobs[i].start();
         }
     }
     return NULL;
 }
 
-const void* NativeCodeCache::findSymbolByPrefix(const char* prefix) {
+const void* NativeLib::findSymbolByPrefix(const char* prefix) {
     int prefix_len = strlen(prefix);
     for (int i = 0; i < _count; i++) {
-        const char* blob_name = (const char*)_blobs[i]._method;
+        const char* blob_name = _blobs[i].getName();
         if (blob_name != NULL && strncmp(blob_name, prefix, prefix_len) == 0) {
-            return _blobs[i]._start;
+            return _blobs[i].start();
         }
     }
     return NULL;
 }
+
+void VmCodeCache::add(const void* start, int length, const jmethodID method) {
+    CodeUnit::add(start, length, true)->setMethod(method);
+    if (start < _min_address) {
+      _min_address = start;
+    }
+    if ((void*)((char*)start + length) > _max_address) {
+      _max_address = (void*)((char*)start + length);
+    }
+}
+
+void VmCodeCache::add(const void* start, int length, const char *name) {
+    CodeUnit::add(start, length, true)->setName(name);
+    if (start < _min_address) {
+      _min_address = start;
+    }
+    if ((void*)((char*)start + length) > _max_address) {
+      _max_address = (void*)((char*)start + length);
+    }
+    if (strcmp(name, "Interpreter") == 0) {
+      _interp_min = start;
+      _interp_max = (const void*)((char*)start + length);
+    }
+}
+

--- a/src/codeCache.cpp
+++ b/src/codeCache.cpp
@@ -54,7 +54,7 @@ CodeBlob *CodeUnit::add(const void* start, int length, bool insert) {
 void VmCodeCache::remove(const void* start, jmethodID method) {
     int pos = binarySearchPosition(start);
     if (_count > (pos + 1)) {
-      memmove(_blobs + pos, _blobs + (pos + 1), (sizeof(CodeBlob)) * (_count - pos -1)); 
+        memmove(_blobs + pos, _blobs + (pos + 1), (sizeof(CodeBlob)) * (_count - pos -1));
     }
     _count--;
 }
@@ -141,15 +141,14 @@ const char* NativeLib::binarySearch(const void* address) {
     if (low > 0 && _blobs[low - 1].start() == _blobs[low - 1].end()) {
         return _blobs[low - 1].getName();
     }
-
-   return _name;
+    return _name;
 }
 
 const void* NativeLib::findSymbol(const char* name) {
     for (int i = 0; i < _count; i++) {
         const char* blob_name = _blobs[i].getName();
         if (blob_name != NULL && strcmp(blob_name, name) == 0) {
-          return _blobs[i].start();
+            return _blobs[i].start();
         }
     }
     return NULL;
@@ -169,24 +168,23 @@ const void* NativeLib::findSymbolByPrefix(const char* prefix) {
 void VmCodeCache::add(const void* start, int length, const jmethodID method) {
     CodeUnit::add(start, length, true)->setMethod(method);
     if (start < _min_address) {
-      _min_address = start;
+        _min_address = start;
     }
     if ((void*)((char*)start + length) > _max_address) {
-      _max_address = (void*)((char*)start + length);
+        _max_address = (void*)((char*)start + length);
     }
 }
 
 void VmCodeCache::add(const void* start, int length, const char *name) {
     CodeUnit::add(start, length, true)->setName(name);
     if (start < _min_address) {
-      _min_address = start;
+        _min_address = start;
     }
     if ((void*)((char*)start + length) > _max_address) {
-      _max_address = (void*)((char*)start + length);
+        _max_address = (void*)((char*)start + length);
     }
     if (strcmp(name, "Interpreter") == 0) {
-      _interp_min = start;
-      _interp_max = (const void*)((char*)start + length);
+        _interp_min = start;
+        _interp_max = (const void*)((char*)start + length);
     }
 }
-

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -18,16 +18,27 @@
 #define _CODECACHE_H
 
 #include <jvmti.h>
+#include "vmEntry.h"
 
-
-const int INITIAL_CODE_CACHE_CAPACITY = 1000;
+const int INITIAL_CODE_CACHE_CAPACITY = 1024;
 
 
 class CodeBlob {
-  public:
+  private:
+    void* _id;
     const void* _start;
-    const void* _end;
-    jmethodID _method;
+    unsigned    _length;
+    bool        _isNmethod;
+  public:
+    const void* start() { return _start; }
+    const void* end() { return (const char*)_start + _length; }
+    void init(const void* s, unsigned l) { _start = s; _length = l; }
+
+    bool isNmethod() { return _isNmethod; }
+    void setName(const char *n) { _id = (void *) n; _isNmethod = false; }
+    void setMethod(jmethodID m) { _id = m; _isNmethod = true; }
+    char *getName() { return isNmethod() ? NULL : (char *)_id; }
+    jmethodID getMethod() { return isNmethod() ? (jmethodID)_id : NULL; }
 
     static int comparator(const void* c1, const void* c2) {
         CodeBlob* cb1 = (CodeBlob*)c1;
@@ -36,57 +47,66 @@ class CodeBlob {
             return -1;
         } else if (cb1->_start > cb2->_start) {
             return 1;
-        } else if (cb1->_end == cb2->_end) {
+        } else if (cb1->end() == cb2->end()) {
             return 0;
         } else {
-            return cb1->_end > cb2->_end ? -1 : 1;
+          return cb1->end() > cb2->end() ? -1 : 1;
         }
     }
 };
 
-
-class CodeCache {
+// Base class for models of native libs and the VM's code cache
+class CodeUnit {
   protected:
     int _capacity;
     int _count;
     CodeBlob* _blobs;
+    const void* _min_address;
+    const void* _max_address;
+    const int binarySearchPosition(const void* addr);
 
     void expand();
 
   public:
-    CodeCache() {
+    CodeUnit() {
         _capacity = INITIAL_CODE_CACHE_CAPACITY;
         _count = 0;
         _blobs = new CodeBlob[_capacity];
+        _min_address = (void *)(-1l);
+        _max_address = (void *)(0l);
     }
 
-    ~CodeCache() {
+    ~CodeUnit() {
         delete[] _blobs;
     }
 
-    void add(const void* start, int length, jmethodID method);
-    void remove(const void* start, jmethodID method);
-    jmethodID find(const void* address);
+    CodeBlob *add(const void* start, int length, bool insert);
+    CodeBlob *find(const void* address) {
+      int pos = binarySearchPosition(address);
+      return pos >= 0 ? _blobs + pos : NULL;
+      }
+    bool contains(const void* address) {
+        return address >= _min_address && address < _max_address;
+    }
+    const void *minAddr() { return _min_address; }
+    const void *maxAddr() { return _max_address; }
 };
 
-
-class NativeCodeCache : public CodeCache {
+// Model for native libs
+class NativeLib : public CodeUnit {
   private:
     char* _name;
-    const void* _min_address;
-    const void* _max_address;
-  
-  public:
-    NativeCodeCache(const char* name, const void* min_address = NULL, const void* max_address = NULL);
+    bool _is_kernel;
 
-    ~NativeCodeCache();
+  public:
+    NativeLib(const char* name, const void* min_address = (void *) (-1l), const void* max_address = NULL);
+    bool isKernel() { return _is_kernel; }
+    void setIsKernel() { _is_kernel = true; }
+
+    ~NativeLib();
 
     const char* name() {
         return _name;
-    }
-
-    bool contains(const void* address) {
-        return address >= _min_address && address < _max_address;
     }
 
     void add(const void* start, int length, const char* name);
@@ -94,6 +114,17 @@ class NativeCodeCache : public CodeCache {
     const char* binarySearch(const void* address);
     const void* findSymbol(const char* name);
     const void* findSymbolByPrefix(const char* prefix);
+};
+
+// Model of the VM's code cache
+class VmCodeCache : public CodeUnit {
+    const void *_interp_min;
+    const void *_interp_max;
+  public:
+    void add(const void* start, int length, const jmethodID method);
+    void add(const void* start, int length, const char *name);
+    void remove(const void* start, jmethodID method);
+    bool isInterpreter(const void *pc) { return (pc >= _interp_min) && (pc < _interp_max); }
 };
 
 #endif // _CODECACHE_H

--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -50,7 +50,7 @@ class CodeBlob {
         } else if (cb1->end() == cb2->end()) {
             return 0;
         } else {
-          return cb1->end() > cb2->end() ? -1 : 1;
+            return cb1->end() > cb2->end() ? -1 : 1;
         }
     }
 };
@@ -82,9 +82,9 @@ class CodeUnit {
 
     CodeBlob *add(const void* start, int length, bool insert);
     CodeBlob *find(const void* address) {
-      int pos = binarySearchPosition(address);
-      return pos >= 0 ? _blobs + pos : NULL;
-      }
+        int pos = binarySearchPosition(address);
+        return pos >= 0 ? _blobs + pos : NULL;
+    }
     bool contains(const void* address) {
         return address >= _min_address && address < _max_address;
     }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
 #include "engine.h"
 #include "stackFrame.h"
 
 
 int Engine::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
-                           const void* jit_min_address, const void* jit_max_address) {
+                           VmCodeCache *cc) {
     StackFrame frame(ucontext);
     const void* pc = (const void*)frame.pc();
     uintptr_t fp = frame.fp();
@@ -32,7 +33,7 @@ int Engine::getNativeTrace(void* ucontext, int tid, const void** callchain, int 
     while (depth < max_depth && pc >= valid_pc) {
         callchain[depth++] = pc;
 
-        if (pc >= jit_min_address && pc < jit_max_address) {
+        if (cc->contains(pc)) {
             break;
         }
 

--- a/src/engine.h
+++ b/src/engine.h
@@ -18,7 +18,7 @@
 #define _ENGINE_H
 
 #include "arguments.h"
-
+#include "codeCache.h"
 
 class Engine {
   public:
@@ -32,7 +32,7 @@ class Engine {
     virtual void onThreadEnd() {}
 
     virtual int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
-                               const void* jit_min_address, const void* jit_max_address);
+                               VmCodeCache* cc);
 };
 
 #endif // _ENGINE_H

--- a/src/flameGraph.cpp
+++ b/src/flameGraph.cpp
@@ -660,20 +660,20 @@ int FlameGraph::calcPercentage(int *out, u64 total, u64 interp, u64 inlined, u64
     double cor = 0.0;
     double sum = 0.0;
     for (int i = 0; i < 3; ++i) {
-      if (fp[i] > 0.0 && fp[i] < 1.0) {
-        cor += 1.0 - fp[i];
-      } else {
-        sum += fp[i];
-      }
+        if (fp[i] > 0.0 && fp[i] < 1.0) {
+            cor += 1.0 - fp[i];
+        } else {
+            sum += fp[i];
+        }
     }
     for (int i = 0; i < 3; ++i) {
-      if (fp[i] > 0.0 && fp[i] < 1.0) {
-        out[i] = 1;
-      } else if (fp[i] >= 1.0) {
-        out[i] = int(fp[i] - (cor * fp[i] / sum));
-      } else {
-        out[i] = 0;
-      }
+        if (fp[i] > 0.0 && fp[i] < 1.0) {
+            out[i] = 1;
+        } else if (fp[i] >= 1.0) {
+            out[i] = int(fp[i] - (cor * fp[i] / sum));
+        } else {
+            out[i] = 0;
+        }
     }
 
     return ret;
@@ -703,16 +703,16 @@ double FlameGraph::printFrame(std::ostream& out, const std::string& name, const 
              "<title>%s (%.2f%%, samples: %s total",full_title.c_str(), f._total * _pct, Format().thousands(f._total));
         out << _buf;
         if (f._inlined != 0) {
-        	snprintf(_buf, sizeof(_buf), ", %s inlined into top", Format().thousands(f._inlined));
-        	out << _buf;
+            snprintf(_buf, sizeof(_buf), ", %s inlined into top", Format().thousands(f._inlined));
+            out << _buf;
         }
         if (f._compiled != 0) {
-        	snprintf(_buf, sizeof(_buf), ", %s compiled on top", Format().thousands(f._compiled));
-        	out << _buf;
+            snprintf(_buf, sizeof(_buf), ", %s compiled on top", Format().thousands(f._compiled));
+            out << _buf;
         }
         if (f._interp != 0) {
-        	snprintf(_buf, sizeof(_buf), ", %s interpreted on top", Format().thousands(f._interp));
-        	out << _buf;
+            snprintf(_buf, sizeof(_buf), ", %s interpreted on top", Format().thousands(f._interp));
+            out << _buf;
         }
         out <<  ")</title>\n";
 
@@ -720,23 +720,23 @@ double FlameGraph::printFrame(std::ostream& out, const std::string& name, const 
         int colors = calcPercentage(percentage, f._total, f._interp, f._inlined, f._compiled);
         // more than one color required, we're sure it's a java frame
         if (colors >= 2) {
-          snprintf(_buf, sizeof(_buf), "<defs>\n<linearGradient id=\"Gradient%d\">\n", _gradient);
-          out << _buf;
-          int last = 0;
-          for (int i = 0; i < 3; ++i) {
-            if (percentage[i] != 0) {
-              int start = last;
-              int end = (start + percentage[i] - 1) > 100 ? 100 : (start + percentage[i] - 1);
-              last += percentage[i];
-              int color;
-              if (i == 0) color = selectFramePalette(FRAME_TYPE_INLINED_JAVA).pickColor();
-              if (i == 1) color = selectFramePalette(FRAME_TYPE_INTERPRETED_JAVA).pickColor();
-              if (i == 2) color = selectFramePalette(FRAME_TYPE_COMPILED_JAVA).pickColor();
-              snprintf(_buf, sizeof(_buf), "<stop offset=\"%d%%\" stop-color=\"#%06x\"/>\n", start, color);
-              out << _buf;
-              snprintf(_buf, sizeof(_buf), "<stop offset=\"%d%%\" stop-color=\"#%06x\"/>\n", end, color);
-              out << _buf;
-            }
+            snprintf(_buf, sizeof(_buf), "<defs>\n<linearGradient id=\"Gradient%d\">\n", _gradient);
+            out << _buf;
+            int last = 0;
+            for (int i = 0; i < 3; ++i) {
+                if (percentage[i] != 0) {
+                    int start = last;
+                    int end = (start + percentage[i] - 1) > 100 ? 100 : (start + percentage[i] - 1);
+                    last += percentage[i];
+                    int color;
+                    if (i == 0) color = selectFramePalette(FRAME_TYPE_INLINED_JAVA).pickColor();
+                    if (i == 1) color = selectFramePalette(FRAME_TYPE_INTERPRETED_JAVA).pickColor();
+                    if (i == 2) color = selectFramePalette(FRAME_TYPE_COMPILED_JAVA).pickColor();
+                    snprintf(_buf, sizeof(_buf), "<stop offset=\"%d%%\" stop-color=\"#%06x\"/>\n", start, color);
+                    out << _buf;
+                    snprintf(_buf, sizeof(_buf), "<stop offset=\"%d%%\" stop-color=\"#%06x\"/>\n", end, color);
+                    out << _buf;
+                }
           }
           out << "</linearGradient>\n</defs>\n";
           snprintf(_buf, sizeof(_buf),
@@ -766,11 +766,11 @@ double FlameGraph::printFrame(std::ostream& out, const std::string& name, const 
         // sort subnodes to make inlined frames appear to the left
         std::vector<Node> subnodes;
         for (std::map<std::string, Trie>::const_iterator it = f._children.begin(); it != f._children.end(); ++it) {
-          subnodes.push_back(Node(it->first, it->second));
+            subnodes.push_back(Node(it->first, it->second));
         }
         std::sort(subnodes.begin(), subnodes.end(), compareNodes);
         for (size_t i = 0; i < subnodes.size(); i++) {
-          x += printFrame(out, subnodes[i]._name, *subnodes[i]._trie, x, y);
+            x += printFrame(out, subnodes[i]._name, *subnodes[i]._trie, x, y);
         }
     }
 
@@ -851,18 +851,18 @@ const Palette& FlameGraph::selectFramePalette(char c) {
         salmon ("salmon",  0xf0a07a, 16, 32, 32);
 
     switch(c) {
-    case FRAME_TYPE_INTERPRETED_JAVA: return magenta; // interpreted java
-    case FRAME_TYPE_INLINED_JAVA: return aqua; // inlined java
-    case FRAME_TYPE_COMPILED_JAVA: return green; // compiled java
-    case FRAME_TYPE_UNKNOWN_JAVA: return green; // unknown java
-    case FRAME_TYPE_OUTSIDE_TLAB: return brown; // VMSymbol* specifically for allocations outside TLAB
-    case FRAME_TYPE_THREAD: return salmon; // thread
-    case FRAME_TYPE_BOTTOM: return white; // thread
-    case FRAME_TYPE_CPP: return yellow; // c++
-    case FRAME_TYPE_VMSYM: return aqua; // locked object
-    case FRAME_TYPE_KERNEL: return brown; // locked object
-    case FRAME_TYPE_ERROR: return red; // locked object
-    default:  return red; // other native
+        case FRAME_TYPE_INTERPRETED_JAVA: return magenta; // interpreted java
+        case FRAME_TYPE_INLINED_JAVA: return aqua; // inlined java
+        case FRAME_TYPE_COMPILED_JAVA: return green; // compiled java
+        case FRAME_TYPE_UNKNOWN_JAVA: return green; // unknown java
+        case FRAME_TYPE_OUTSIDE_TLAB: return brown; // VMSymbol* specifically for allocations outside TLAB
+        case FRAME_TYPE_THREAD: return salmon; // thread
+        case FRAME_TYPE_BOTTOM: return white; // thread
+        case FRAME_TYPE_CPP: return yellow; // c++
+        case FRAME_TYPE_VMSYM: return aqua; // locked object
+        case FRAME_TYPE_KERNEL: return brown; // locked object
+        case FRAME_TYPE_ERROR: return red; // locked object
+        default:  return red; // other native
     }
 }
 

--- a/src/flameGraph.h
+++ b/src/flameGraph.h
@@ -58,9 +58,9 @@ class Trie {
         _total += value;
         _self += value;
         switch(type) {
-        case FRAME_TYPE_INTERPRETED_JAVA: _interp += value; return;
-        case FRAME_TYPE_INLINED_JAVA: _inlined += value; return;
-        case FRAME_TYPE_COMPILED_JAVA: _compiled += value; return;
+            case FRAME_TYPE_INTERPRETED_JAVA: _interp += value; return;
+            case FRAME_TYPE_INLINED_JAVA: _inlined += value; return;
+            case FRAME_TYPE_COMPILED_JAVA: _compiled += value; return;
         }
     }
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -382,12 +382,12 @@ class Recording {
         if (mi->_key == 0) {
             mi->_key = _method_map.size();
 
-            if (frame.bci == BCI_NATIVE_FRAME || frame.bci == BCI_ERROR || method == NULL) {
+            if (frame.bci == BCI_NATIVE_FRAME || frame.bci == BCI_KERNEL_FRAME || frame.bci == BCI_ERROR || method == NULL) {
                 std::string name;
                 FrameTypeId type = demangle((const char*)method, name);
                 mi->_class = lookup(_class_map, "");
                 mi->_name = lookup(_symbol_map, name);
-                mi->_sig = lookup(_symbol_map, type == FRAME_KERNEL ? "(Lk;)L;" : "()L;");
+                mi->_sig = lookup(_symbol_map, frame.bci == BCI_KERNEL_FRAME ? "(Lk;)L;" : "()L;");
                 mi->_modifiers = 0x100;
                 mi->_type = type;
 

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -150,8 +150,8 @@ const char* FrameName::name(ASGCT_CallFrame& frame) {
     }
 
     switch (frame.bci) {
-         case BCI_KERNEL_FRAME:
-         case BCI_NATIVE_FRAME: {
+        case BCI_KERNEL_FRAME:
+        case BCI_NATIVE_FRAME: {
              const char* symbol_name = cppDemangle((const char*)frame.method_id);
              return symbol_name;
          }

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -43,7 +43,7 @@ class FrameName {
 
     char* truncate(char* name, int max_length);
     const char* cppDemangle(const char* name);
-    char* javaMethodName(jmethodID method);
+    char* javaMethodName(jmethodID method, char type);
     char* javaClassName(const char* symbol, int length, int style);
 
   public:

--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -45,7 +45,7 @@ Error LockTracer::start(Arguments& args) {
     }
 
     if (_original_Unsafe_Park == NULL) {
-        NativeCodeCache* libjvm = Profiler::_instance.jvmLibrary();
+        NativeLib* libjvm = Profiler::_instance.jvmLibrary();
         _original_Unsafe_Park = (UnsafeParkFunc)libjvm->findSymbol("Unsafe_Park");
         if (_original_Unsafe_Park == NULL) {
             // In some macOS builds of JDK 11 Unsafe_Park appears to have a C++ decorated name

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -19,7 +19,7 @@
 
 #include <signal.h>
 #include "engine.h"
-
+#include "codeCache.h"
 
 class PerfEvent;
 class PerfEventType;
@@ -51,7 +51,7 @@ class PerfEvents : public Engine {
     void onThreadEnd();
 
     int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
-                       const void* jit_min_address, const void* jit_max_address);
+                       VmCodeCache *cc);
 
     static bool supported();
     static const char* getEventName(int event_id);

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -500,7 +500,7 @@ void PerfEvents::onThreadEnd() {
 }
 
 int PerfEvents::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
-                               const void* jit_min_address, const void* jit_max_address) {
+                               VmCodeCache* cc) {
     PerfEvent* event = &_events[tid];
     if (!event->tryLock()) {
         return 0;  // the event is being destroyed
@@ -525,7 +525,7 @@ int PerfEvents::getNativeTrace(void* ucontext, int tid, const void** callchain, 
                     if (ip < PERF_CONTEXT_MAX) {
                         const void* iptr = (const void*)ip;
                         callchain[depth++] = iptr;
-                        if (iptr >= jit_min_address && iptr < jit_max_address) {
+                        if (cc->contains(iptr)) {
                             // Stop at the first Java frame
                             break;
                         }

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -49,7 +49,7 @@ void PerfEvents::onThreadEnd() {
 }
 
 int PerfEvents::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth,
-                               const void* jit_min_address, const void* jit_max_address) {
+                               VmCodeCache* cc) {
     return 0;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -124,32 +124,32 @@ void Profiler::copyToFrameBuffer(int num_frames, ASGCT_CallFrame* frames, CallTr
 }
 
 u64 Profiler::hashMethod(jmethodID method, jint bci) {
-      const u64 M = 0xc6a4a7935bd1e995ULL;
-      const int R = 47;
-      u64 h = M + M;
+    const u64 M = 0xc6a4a7935bd1e995ULL;
+    const int R = 47;
+    u64 h = M + M;
 
-      u64 k = (u64)method;
-      k *= M;
-      k ^= k >> R;
-      k *= M;
-      h ^= k;
-      h *= M;
+    u64 k = (u64)method;
+    k *= M;
+    k ^= k >> R;
+    k *= M;
+    h ^= k;
+    h *= M;
 
-      k = M * (u64)bci;
-      k ^= k >> R;
-      k *= M;
-      h ^= k;
-      h *= M;
+    k = M * (u64)bci;
+    k ^= k >> R;
+    k *= M;
+    h ^= k;
+    h *= M;
 
-      h ^= h >> R;
-      h *= M;
-      h ^= h >> R;
+    h ^= h >> R;
+    h *= M;
+    h ^= h >> R;
 
-      return h;
+    return h;
 }
 
 void Profiler::storeMethod(jmethodID method, jint bci, u64 counter) {
-  u64 hash = hashMethod(method, bci);
+    u64 hash = hashMethod(method, bci);
     int bucket = (int)(hash % MAX_CALLTRACES);
     int i = bucket;
 
@@ -780,8 +780,8 @@ void Profiler::dumpSummary(std::ostream& out) {
     empty = 0;
     collisions = 0;
     for (int i = 0 ; i < MAX_CALLTRACES; ++i) {
-      if (_methods[i]._method.method_id == NULL) empty++;
-      else if ((int)(hashMethod(_methods[i]._method.method_id, _methods[i]._method.bci) % MAX_CALLTRACES) != i) collisions++;
+        if (_methods[i]._method.method_id == NULL) empty++;
+        else if ((int)(hashMethod(_methods[i]._method.method_id, _methods[i]._method.bci) % MAX_CALLTRACES) != i) collisions++;
     }
     double mb_usage = 100.00 - (100.00 * empty / MAX_CALLTRACES);
     out << "Method buffer usage : " << mb_usage << "% (" << MAX_CALLTRACES - empty << " entries, " << collisions << " collisions)";
@@ -918,25 +918,25 @@ char Profiler::getFrameType(jint bci) {
         return FRAME_TYPE_COMPILED_JAVA;
     }
     switch (bci) {
-    case BCI_NATIVE_FRAME: return FRAME_TYPE_NATIVE;
-    case BCI_SYMBOL: return FRAME_TYPE_VMSYM;
-    case BCI_SYMBOL_OUTSIDE_TLAB: return FRAME_TYPE_OUTSIDE_TLAB;
-    case BCI_THREAD_ID: return FRAME_TYPE_THREAD;
-    case BCI_KERNEL_FRAME: return FRAME_TYPE_KERNEL;
-    case BCI_ERROR: return FRAME_TYPE_ERROR;
+        case BCI_NATIVE_FRAME: return FRAME_TYPE_NATIVE;
+        case BCI_SYMBOL: return FRAME_TYPE_VMSYM;
+        case BCI_SYMBOL_OUTSIDE_TLAB: return FRAME_TYPE_OUTSIDE_TLAB;
+        case BCI_THREAD_ID: return FRAME_TYPE_THREAD;
+        case BCI_KERNEL_FRAME: return FRAME_TYPE_KERNEL;
+        case BCI_ERROR: return FRAME_TYPE_ERROR;
     }
     return FRAME_TYPE_UNKNOWN_JAVA;
 }
 
 jint Profiler::unOffsetBci(jint bci) {
   if (bci >= (BCI_OFFSET_INLINED +  BCI_SMALLEST_USED_BY_VM)) {
-    return bci - BCI_OFFSET_INLINED;
+      return bci - BCI_OFFSET_INLINED;
   }
   if (bci >= (BCI_OFFSET_INTERP +  BCI_SMALLEST_USED_BY_VM)) {
-    return bci - BCI_OFFSET_INTERP;
+      return bci - BCI_OFFSET_INTERP;
   }
   if (bci >= (BCI_OFFSET_COMP +  BCI_SMALLEST_USED_BY_VM)) {
-    return bci - BCI_OFFSET_COMP;
+      return bci - BCI_OFFSET_COMP;
   }
   return bci;
 }
@@ -969,7 +969,7 @@ void Profiler::dumpFlat(std::ostream& out, Arguments& args) {
         char type = getFrameType(bci);
         bci = unOffsetBci(bci);
         snprintf(buf, sizeof(buf) - 1, "%12lld  %6.2f%%  %7lld     %c  %5d  %s\n",
-        		method->_counter, method->_counter * percent, method->_samples, type, bci, frame_name);
+                 method->_counter, method->_counter * percent, method->_samples, type, bci, frame_name);
         out << buf;
     }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -206,10 +206,6 @@ class Profiler {
                                            jint code_size, const void* code_addr,
                                            jint map_length, const jvmtiAddrLocationMap* map,
                                            const void* compile_info) {
-      char* name;
-      char* sign;
-      char* gnrc;
-      jvmti->GetMethodName(method, &name, &sign, &gnrc);
         _instance.addJavaMethod(code_addr, code_size, method);
     }
 

--- a/src/symbols.h
+++ b/src/symbols.h
@@ -30,8 +30,8 @@ class Symbols {
     static bool _have_kernel_symbols;
 
   public:
-    static void parseKernelSymbols(NativeCodeCache* cc);
-    static void parseLibraries(NativeCodeCache** array, volatile int& count, int size);
+    static void parseKernelSymbols(NativeLib* cc);
+    static void parseLibraries(NativeLib** array, volatile int& count, int size);
 
     static bool haveKernelSymbols() {
         return _have_kernel_symbols;

--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -31,7 +31,7 @@
 
 class MachOParser {
   private:
-    NativeCodeCache* _cc;
+    NativeLib* _cc;
     const mach_header* _image_base;
 
     static const char* add(const void* base, uint32_t offset) {
@@ -102,10 +102,10 @@ class MachOParser {
     }
 
   public:
-    MachOParser(NativeCodeCache* cc, const mach_header* image_base) : _cc(cc), _image_base(image_base) {
+    MachOParser(NativeLib* cc, const mach_header* image_base) : _cc(cc), _image_base(image_base) {
     }
 
-    static void parseFile(NativeCodeCache* cc, const mach_header* image_base, const char* file_name) {
+    static void parseFile(NativeLib* cc, const mach_header* image_base, const char* file_name) {
         int fd = open(file_name, O_RDONLY);
         if (fd == -1) {
             return;
@@ -130,10 +130,10 @@ Mutex Symbols::_parse_lock;
 std::set<const void*> Symbols::_parsed_libraries;
 bool Symbols::_have_kernel_symbols = false;
 
-void Symbols::parseKernelSymbols(NativeCodeCache* cc) {
+void Symbols::parseKernelSymbols(NativeLib* cc) {
 }
 
-void Symbols::parseLibraries(NativeCodeCache** array, volatile int& count, int size) {
+void Symbols::parseLibraries(NativeLib** array, volatile int& count, int size) {
     MutexLocker ml(_parse_lock);
     uint32_t images = _dyld_image_count();
 
@@ -145,7 +145,7 @@ void Symbols::parseLibraries(NativeCodeCache** array, volatile int& count, int s
 
         const char* path = _dyld_get_image_name(i);
 
-        NativeCodeCache* cc = new NativeCodeCache(path);
+        NativeLib* cc = new NativeLib(path);
         MachOParser::parseFile(cc, image_base, path);
 
         cc->sort();

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -22,7 +22,7 @@
 
 // ASGCT_CallFrames where method_id has special meaning (not jmethodID) are distinguished by the bci field
 enum ASGCT_CallFrameType {
-	BCI_SMALLEST_USED_BY_VM = -9,      // small negative BCIs are used by the VM (-6 is the smallest currently)
+    BCI_SMALLEST_USED_BY_VM = -9,      // small negative BCIs are used by the VM (-6 is the smallest currently)
     BCI_NATIVE_FRAME        = -10,     // method_id is native function name (char*)
     BCI_SYMBOL              = -11,     // method_id is VMSymbol*
     BCI_SYMBOL_OUTSIDE_TLAB = -12,     // VMSymbol* specifically for allocations outside TLAB
@@ -50,7 +50,7 @@ enum ASGCT_Failure {
     ticks_skipped               = -11,
     ASGCT_FAILURE_TYPES         = 12
 };
-  
+
 typedef struct {
     jint bci;
     jmethodID method_id;

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -20,13 +20,18 @@
 #include <jvmti.h>
 
 
-// Denotes ASGCT_CallFrame where method_id has special meaning (not jmethodID)
+// ASGCT_CallFrames where method_id has special meaning (not jmethodID) are distinguished by the bci field
 enum ASGCT_CallFrameType {
-    BCI_NATIVE_FRAME        = -10,  // method_id is native function name (char*)
-    BCI_SYMBOL              = -11,  // method_id is VMSymbol*
-    BCI_SYMBOL_OUTSIDE_TLAB = -12,  // VMSymbol* specifically for allocations outside TLAB
-    BCI_THREAD_ID           = -13,  // method_id designates a thread
-    BCI_ERROR               = -14,  // method_id is error string
+	BCI_SMALLEST_USED_BY_VM = -9,      // small negative BCIs are used by the VM (-6 is the smallest currently)
+    BCI_NATIVE_FRAME        = -10,     // method_id is native function name (char*)
+    BCI_SYMBOL              = -11,     // method_id is VMSymbol*
+    BCI_SYMBOL_OUTSIDE_TLAB = -12,     // VMSymbol* specifically for allocations outside TLAB
+    BCI_THREAD_ID           = -13,     // method_id designates a thread
+    BCI_ERROR               = -14,     // method_id is error string
+    BCI_KERNEL_FRAME        = -15,     // method_id is native function name (char*) in the OS kernel
+    BCI_OFFSET_COMP         = 0x10000, // offset added to bci for compiled java method
+    BCI_OFFSET_INTERP       = 0x20000, // offset added to bci for interpreted java method
+    BCI_OFFSET_INLINED      = 0x30000, // offset added to bci for inlined java method
 };
 
 // See hotspot/src/share/vm/prims/forte.cpp
@@ -45,7 +50,7 @@ enum ASGCT_Failure {
     ticks_skipped               = -11,
     ASGCT_FAILURE_TYPES         = 12
 };
-
+  
 typedef struct {
     jint bci;
     jmethodID method_id;
@@ -59,6 +64,21 @@ typedef struct {
 
 typedef void (*AsyncGetCallTrace)(ASGCT_CallTrace*, jint, void*);
 
+// Frame types used for output (output generators use these directly)
+enum StoredFrameType {
+    FRAME_TYPE_NATIVE           = 'n',
+    FRAME_TYPE_KERNEL           = 'k',
+    FRAME_TYPE_VMSYM            = 'v',
+    FRAME_TYPE_OUTSIDE_TLAB     = 'o',
+    FRAME_TYPE_THREAD           = 't',
+    FRAME_TYPE_COMPILED_JAVA    = 'J',
+    FRAME_TYPE_INTERPRETED_JAVA = 'I',
+    FRAME_TYPE_INLINED_JAVA     = 'i',
+    FRAME_TYPE_UNKNOWN_JAVA     = 'j',
+    FRAME_TYPE_CPP              = 'p',
+    FRAME_TYPE_BOTTOM           = 'b',
+    FRAME_TYPE_ERROR            = 'e',
+};
 
 class VM {
   private:

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -30,7 +30,7 @@ int VMStructs::_osthread_id_offset = -1;
 bool VMStructs::_has_perm_gen = false;
 jfieldID VMStructs::_eetop = NULL;
 
-static uintptr_t readSymbol(NativeCodeCache* lib, const char* symbol_name) {
+static uintptr_t readSymbol(NativeLib* lib, const char* symbol_name) {
     const void* symbol = lib->findSymbol(symbol_name);
     if (symbol == NULL) {
         // Avoid JVM crash in case of missing symbols
@@ -39,7 +39,7 @@ static uintptr_t readSymbol(NativeCodeCache* lib, const char* symbol_name) {
     return *(uintptr_t*)symbol;
 }
 
-void VMStructs::init(NativeCodeCache* libjvm) {
+void VMStructs::init(NativeLib* libjvm) {
     if (available()) {
         return;
     }

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -39,7 +39,7 @@ class VMStructs {
     }
 
   public:
-    static void init(NativeCodeCache* libjvm);
+    static void init(NativeLib* libjvm);
 
     static bool available() {
         return _klass_name_offset >= 0

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -30,7 +30,7 @@ long WallClock::_interval;
 bool WallClock::_sample_idle_threads;
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-  Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
+    Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
 }
 
 Error WallClock::start(Arguments& args) {

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -30,7 +30,7 @@ long WallClock::_interval;
 bool WallClock::_sample_idle_threads;
 
 void WallClock::signalHandler(int signo, siginfo_t* siginfo, void* ucontext) {
-    Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
+  Profiler::_instance.recordSample(ucontext, _interval, 0, NULL);
 }
 
 Error WallClock::start(Arguments& args) {


### PR DESCRIPTION
Async profiler doesn't distinguish frame types (compiled/inlined/interpreted), which is relevant information for developers. With this change the frame type is tracked at least for top frames.

The basic principle used to gather the frame type is simple: If the pc of topmost java frame is within the interpreter, the top frame is interpreted. If not, the `methodID` of the topmost java frame is looked up in the code cache model. Then, the `vframe` stack trace obtained from the VM is walked till the `methodID` is found. This is the topmost physical frame. The ones possibly found above this are virtual frames of inlined methods.

I had to change the code in several places in order to obtain the necessary information.

The most profound change was necessary to the code cache model. The Hotspot VM has only one code cache for nmethods as well as for other blobs, e.g. the interpreter. Even with the segmented code cache introduced with Java 9 IIRC, it is still one continuous memory region. I've changed async profiler's model accordingly. There is now only one VM code cache where each blob can either be an `nmethod` which has a `methodID` or a non-nmethod which has a `cstring` name. The VM code cache is now ordered to allow for binary searching. Each new blob has to be inserted in the appropriate location. The new class is called `VmCodeCache.` I've renamed the model for libraries to `NativeLib` to be a little bit more clear. Both inherit from a base class called `CodeUnit.`

`recordSample` has been extended in the way described above. Frame type information is stored as an offset to the bci. Therefore, I had to slightly change the hashing mechanism to take the bci into account. This is done for all frames, even though it is not absolutely required right now, but I think it might be the basis for a worthwhile future extension.

Frames are now color coded in the flame graph (svg) output. Interpreted top frames appear in magenta, while inlined frames are blue (aqua). Frames of the same method may occur in different types (e.g. interpreted first and inlined later on), what is represented by a gradient. In order to transfer the information from the traces to the flame graph generator, the `Trie` class has been extended. The type of a frame is coded by a sigle character extension to its name. This now works independently from the annotation mechanism.

There are a few extensions to the simple output functions (summary, flat and traces) which are self-explanatory. jfr output still works but doesn't take advantage of the additional information, yet.

Finally, I've changed the color of "all" and threads dummy frames in the flamer graph (svg) output to white (gray) and salmon respectively, while the new ERROR frames continue to appear in red. This, however, is actually unrelated to the rest of the change and it can be easily be reverted or modified to any other color scheme.

Please see the attachment for an example flame graph:
[out.svg.zip](https://github.com/jvm-profiling-tools/async-profiler/files/2982879/out.svg.zip)
