### PR TITLE
keep all method displays consistent

### DIFF
--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -139,13 +139,13 @@ const char* FrameName::name(ASGCT_CallFrame& frame) {
 
         case BCI_SYMBOL: {
             VMSymbol* symbol = (VMSymbol*)frame.method_id;
-            char* class_name = javaClassName(symbol->body(), symbol->length(), _simple, true);
+            char* class_name = javaClassName(symbol->body(), symbol->length(), _simple, _dotted);
             return strcat(class_name, _dotted ? "" : "_[i]");
         }
 
         case BCI_SYMBOL_OUTSIDE_TLAB: {
             VMSymbol* symbol = (VMSymbol*)((uintptr_t)frame.method_id ^ 1);
-            char* class_name = javaClassName(symbol->body(), symbol->length(), _simple, true);
+            char* class_name = javaClassName(symbol->body(), symbol->length(), _simple, _dotted);
             return strcat(class_name, _dotted ? " (out)" : "_[k]");
         }
 


### PR DESCRIPTION
Keep all method displays consistent.
Parameter _dotted should be passed all through.
Hard code need be removed like below:
'javaClassName(symbol->body(), symbol->length(), _simple, true)