### PR TITLE
Document the placeholders in the file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,10 @@ Example: `./profiler.sh -t 8983`
 * `--title TITLE`, `--width PX`, `--height PX`, `--minwidth PX`, `--reverse` - FlameGraph parameters.  
 Example: `./profiler.sh -f profile.svg --title "Sample CPU profile" --minwidth 0.5 8983`
 
-* `-f FILENAME` - the file name to dump the profile information to.  
-Example: `./profiler.sh -o collapsed -f /tmp/traces.txt 8983`
+* `-f FILENAME` - the file name to dump the profile information to.
+`%p` in the file name is expanded to the PID of the target JVM;
+`%t` — to the timestamp.
+Example: `./profiler.sh -o collapsed -f /tmp/traces-%t.txt 8983`
 
 * `--all-user` - include only user-mode events. This option is helpful when kernel profiling
 is restricted by `perf_event_paranoid` settings.  

--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Example: `./profiler.sh -f profile.svg --title "Sample CPU profile" --minwidth 0
 
 * `-f FILENAME` - the file name to dump the profile information to.
 `%p` in the file name is expanded to the PID of the target JVM;
-`%t` — to the timestamp.
+`%t` — to the timestamp at the time of command invocation.
 Example: `./profiler.sh -o collapsed -f /tmp/traces-%t.txt 8983`
 
 * `--all-user` - include only user-mode events. This option is helpful when kernel profiling

--- a/README.md
+++ b/README.md
@@ -324,9 +324,9 @@ Example: `./profiler.sh -t 8983`
 * `--title TITLE`, `--width PX`, `--height PX`, `--minwidth PX`, `--reverse` - FlameGraph parameters.  
 Example: `./profiler.sh -f profile.svg --title "Sample CPU profile" --minwidth 0.5 8983`
 
-* `-f FILENAME` - the file name to dump the profile information to.
-`%p` in the file name is expanded to the PID of the target JVM;
-`%t` — to the timestamp at the time of command invocation.
+* `-f FILENAME` - the file name to dump the profile information to.  
+`%p` in the file name is expanded to the PID of the target JVM;  
+`%t` - to the timestamp at the time of command invocation.  
 Example: `./profiler.sh -o collapsed -f /tmp/traces-%t.txt 8983`
 
 * `--all-user` - include only user-mode events. This option is helpful when kernel profiling


### PR DESCRIPTION
Document the placeholders for the PID and the timestamp
in a filename.

See https://github.com/jvm-profiling-tools/async-profiler/blob/master/src/arguments.cpp#L189-L190