### PR TITLE
Update CentOS cmd to install openjdk debug symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ or for OpenJDK 11:
 On CentOS, RHEL and some other RPM-based distributions, this could be done with
 [debuginfo-install](http://man7.org/linux/man-pages/man1/debuginfo-install.1.html) utility:
 ```
-# debuginfo-install java-1.8.0-openjdk
+# yum install java-1.8.0-openjdk-debuginfo.x86_64
 ```
 
 On Gentoo the `icedtea` OpenJDK package can be built with the per-package setting


### PR DESCRIPTION
I checked and found out that you already have this command, "yum install java-1.8.0-openjdk-debuginfo.x86_64", when you answered this issue, https://github.com/jvm-profiling-tools/async-profiler/issues/206". But probably you just forgot sync with the readme.