### PR TITLE
port async profiler to Power Linux little endian (linuxppc64le)

### DIFF
--- a/src/allocTracer.h
+++ b/src/allocTracer.h
@@ -58,6 +58,8 @@ class AllocTracer : public Engine {
     static void signalHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void recordAllocation(void* ucontext, uintptr_t rklass, uintptr_t rsize, bool outside_tlab); 
 
+    static void (*_next_handler)(int, siginfo_t *, void *);
+
   public:
     const char* name() {
         return "alloc";

--- a/src/os.h
+++ b/src/os.h
@@ -38,6 +38,7 @@ class OS {
     static bool isSignalSafeTLS();
     static bool isJavaLibraryVisible();
     static void installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*));
+    static void* getSignalHandler(int signo);
     static void sendSignalToThread(int thread_id, int signo);
     static ThreadList* listThreads();
 };

--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -116,6 +116,13 @@ void OS::installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*)
     sigaction(signo, &sa, NULL);
 }
 
+void* OS::getSignalHandler(int signo) {
+    struct sigaction oact, nex;
+    sigaction(signo, NULL, &oact);
+
+    return (void*)oact.sa_handler;
+}
+
 void OS::sendSignalToThread(int thread_id, int signo) {
     static const int self_pid = getpid();
 

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -104,6 +104,13 @@ void OS::installSignalHandler(int signo, void (*handler)(int, siginfo_t*, void*)
     sigaction(signo, &sa, NULL);
 }
 
+void* OS::getSignalHandler(int signo) {
+    struct sigaction oact, nex;
+    sigaction(signo, NULL, &oact);
+
+    return (void*)oact.sa_handler;
+}
+
 void OS::sendSignalToThread(int thread_id, int signo) {
    asm volatile("syscall" : : "a"(0x2000148), "D"(thread_id), "S"(signo));
 }

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2017 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Author: Andrei Pangin and Gunter Haug
+ */
+
+#if defined(__PPC64__)
+
+#include "stackFrame.h"
+
+uintptr_t& StackFrame::pc() {
+    return (uintptr_t&)_ucontext->uc_mcontext.regs->nip;
+}
+
+uintptr_t& StackFrame::sp() {
+    return (uintptr_t&)_ucontext->uc_mcontext.regs->gpr[1];
+}
+
+uintptr_t& StackFrame::fp() {
+    return *((uintptr_t*)_ucontext->uc_mcontext.regs->gpr[1]);
+}
+
+uintptr_t StackFrame::arg0() {
+    return (uintptr_t)_ucontext->uc_mcontext.regs->gpr[3];
+}
+
+uintptr_t StackFrame::arg1() {
+    return (uintptr_t)_ucontext->uc_mcontext.regs->gpr[4];
+}
+
+uintptr_t StackFrame::arg2() {
+    return (uintptr_t)_ucontext->uc_mcontext.regs->gpr[5];
+}
+
+uintptr_t StackFrame::arg3() {
+    return (uintptr_t)_ucontext->uc_mcontext.regs->gpr[6];
+}
+
+void StackFrame::ret() {
+    _ucontext->uc_mcontext.regs->nip = _ucontext->uc_mcontext.regs->link;
+}
+
+static inline bool inC1EpilogueCrit(uintptr_t pc) {
+    // C1 epilogue and critical section (posX)
+    //        3821**** add     r1,r1,xx
+    // pos3   xxxxxxxx
+    // pos2   1000e1eb ld      r31,16(r1)
+    // pos1   a603e87f mtlr    r31
+    //        xxxxxxxx
+    //        2000804e blr
+    if (*((unsigned int *)pc + 1) == 0xebe10010 && *((unsigned int *)pc + 2) == 0x7fe803a6 ||
+        *((unsigned int *)pc + 0) == 0xebe10010 && *((unsigned int *)pc + 1) == 0x7fe803a6 ||
+        *((unsigned int *)pc - 1) == 0xebe10010 && *((unsigned int *)pc + 0) == 0x7fe803a6) {
+        return true;
+    }
+
+    return false; // not in critical section
+}
+
+static inline bool inC2PrologueCrit(uintptr_t pc) {
+    // C2 prologue and critical section
+    //        f821**** stdu    r1, (xx)r1
+    // pos1   fa950010 std     r20,16(r21)
+    if (*((unsigned int *)pc) == 0xfa950010 && (*((unsigned int *)pc - 1) &0xFFFF0000 == 0xf8210000)) {
+        return true;
+    }
+
+    return false; // not in critical section
+}
+
+
+bool StackFrame::pop(bool trust_frame_pointer) {
+    // On PPC there is a valid back link to the previous frame at all times. The callee stores
+    // the return address in the caller's frame before it constructs its own frame. After it
+    // has destroyed its frame it restores the link register and returns. A problematic sequence
+    // is the prologue/epilogue of a compiled method before/after frame construction/destruction.
+    // Therefore popping the frame would not help here, as it is not yet/anymore present, rather
+    // more adjusting the pc to the callers pc does the trick. There are two exceptions to this,
+    // One in the prologue of C2 compiled methods and one in the epilogue of C1 compiled methods.
+    if (inC1EpilogueCrit(pc())) {
+        // lr not yet set: use the value stored in the frame
+        pc() = stackAt(2);
+    } else if (inC2PrologueCrit(pc())){
+        // frame constructed but lr not yet stored in it: just do it here
+        *(((unsigned long *) _ucontext->uc_mcontext.regs->gpr[21]) + 2) = (unsigned long) _ucontext->uc_mcontext.regs->gpr[20];
+    } else {
+        // most probably caller's framer is still on top but pc is already in callee: use caller's pc
+        pc() = _ucontext->uc_mcontext.regs->link;
+    }
+
+    return true;
+}
+
+#endif // defined(__PPC64__)

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -12,11 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Author: Andrei Pangin and Gunter Haug
  */
 
-#if defined(__PPC64__)
+#if defined(__PPC64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
 
 #include "stackFrame.h"
 


### PR DESCRIPTION
Hi Andrei,
here is one more pull request. This one is a port of async profiler to LinuxPPC64 little endian. I've tested it extensively and found no issues. The code is mostly straight forward. There is an additional section in arch.h and the new stackFrame_ppc64.cpp file. With these additions the perf event based traces and the wall clock trace as well as the lock trace work perfectly.

Unfortunately the alloc trace requires changes in shared code. The problem is that hotspot itself makes use of SIGTRAP on PPC. Therefore the signal handlers have to be chained, i.e.  the agent's handler has to call the VM's handler once it has been determined that the SIGTRAP is not caused by a trap installed by the agent. There now is an additional function declared in os.h and implemented in the respective os_*.cpp files to get the address of a signal handler currently installed. This is called from allocTracer.cpp and the handler's address is stored in a static variable.

Moreover, the trap instruction may not be installed at the very beginning of a function on PPCLE (see arch.h for an explanation why). I had to introduce the macro `BREAKPOINT_OFFSET` which is 0 on all existing platforms and 2 on PPCLE. `Trap::install()` implemented in allocTracer.cpp now installs the trap with the appropriate offset.