### PR TITLE
Make release version of javac specifiable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 PROFILER_VERSION=1.6
 JATTACH_VERSION=1.5
+RELEASE_VERSION=$(subst 1.,,$(PROFILER_VERSION))
 LIB_PROFILER=libasyncProfiler.so
 JATTACH=jattach
 PROFILER_JAR=async-profiler.jar
@@ -51,7 +52,7 @@ build/$(JATTACH): src/jattach/jattach.c
 
 build/$(PROFILER_JAR): src/java/one/profiler/*.java
 	mkdir -p build/classes
-	$(JAVAC) -source 6 -target 6 -d build/classes $^
+	$(JAVAC) -source ${RELEASE_VERSION} -target ${RELEASE_VERSION} -d build/classes $^
 	$(JAR) cvf $@ -C build/classes .
 	rm -rf build/classes
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROFILER_VERSION=1.6
 JATTACH_VERSION=1.5
-RELEASE_VERSION=$(subst 1.,,$(PROFILER_VERSION))
+JAVAC_RELEASE_VERSION=6
 LIB_PROFILER=libasyncProfiler.so
 JATTACH=jattach
 PROFILER_JAR=async-profiler.jar
@@ -52,7 +52,7 @@ build/$(JATTACH): src/jattach/jattach.c
 
 build/$(PROFILER_JAR): src/java/one/profiler/*.java
 	mkdir -p build/classes
-	$(JAVAC) -source ${RELEASE_VERSION} -target ${RELEASE_VERSION} -d build/classes $^
+	$(JAVAC) -source ${JAVAC_RELEASE_VERSION} -target ${JAVAC_RELEASE_VERSION} -d build/classes $^
 	$(JAR) cvf $@ -C build/classes .
 	rm -rf build/classes
 

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build/$(JATTACH): src/jattach/jattach.c
 
 build/$(PROFILER_JAR): src/java/one/profiler/*.java
 	mkdir -p build/classes
-	$(JAVAC) -source ${JAVAC_RELEASE_VERSION} -target ${JAVAC_RELEASE_VERSION} -d build/classes $^
+	$(JAVAC) -source $(JAVAC_RELEASE_VERSION) -target $(JAVAC_RELEASE_VERSION) -d build/classes $^
 	$(JAR) cvf $@ -C build/classes .
 	rm -rf build/classes
 


### PR DESCRIPTION
It could not build by Java 13 due to hard-coding and out-of-support.

before
<details>

```
$ PROFILER_VERSION=13 JATTACH_VERSION=13 make -e
/jdk-13.0.1/bin/javac -source 6 -target 6 -d build/classes src/java/one/profiler/Events.java src/java/one/profiler/AsyncProfiler.java src/java/one/profiler/AsyncProfilerMXBean.java src/java/one/profiler/Counter.java
warning: [options] bootstrap class path not set in conjunction with -source 6
error: Source option 6 is no longer supported. Use 7 or later.
error: Target option 6 is no longer supported. Use 7 or later.
make: *** [build/async-profiler.jar] Error 2
```
</details>

after
<details>

```
$ PROFILER_VERSION=13 JATTACH_VERSION=13 make -e
/jdk-13.0.1/bin/javac -source 13 -target 13 -d build/classes src/java/one/profiler/Events.java src/java/one/profiler/AsyncProfiler.java src/java/one/profiler/AsyncProfilerMXBean.java src/java/one/profiler/Counter.java
/jdk-13.0.1/bin/jar cvf build/async-profiler.jar -C build/classes .
added manifest
adding: one/(in = 0) (out= 0)(stored 0%)
adding: one/profiler/(in = 0) (out= 0)(stored 0%)
adding: one/profiler/Events.class(in = 405) (out= 288)(deflated 28%)
adding: one/profiler/AsyncProfiler.class(in = 2357) (out= 1175)(deflated 50%)
adding: one/profiler/AsyncProfilerMXBean.class(in = 631) (out= 345)(deflated 45%)
adding: one/profiler/Counter.class(in = 842) (out= 481)(deflated 42%)
rm -rf build/classes
```
</details>