### PR TITLE
resolve relative output file name

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -124,7 +124,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -f)
-            FILE="$2"
+            FILE=$(abspath "$2")
             unset USE_TMP
             shift
             ;;


### PR DESCRIPTION
Output file path is not resolved correctly if relative path is specified.