### PR TITLE
Ensure code blob exists properly

### DIFF
--- a/src/codeCache.h
+++ b/src/codeCache.h
@@ -32,6 +32,8 @@ class CodeBlob {
     const void* _end;
     jmethodID _method;
 
+    bool valid();
+
     static int comparator(const void* c1, const void* c2) {
         CodeBlob* cb1 = (CodeBlob*)c1;
         CodeBlob* cb2 = (CodeBlob*)c2;


### PR DESCRIPTION
Check that code blob is not removed to avoid returning NULL
when another code blob loaded at the similar address range
that was used by removed one

Contributed by @semoro