### PR TITLE
Fix compilation on MacOS

### DIFF
--- a/src/symbols_macos.cpp
+++ b/src/symbols_macos.cpp
@@ -27,7 +27,7 @@
 #include <mach-o/fat.h>
 #include <mach-o/nlist.h>
 #include "symbols.h"
-
+#include "arch.h"
 
 class MachOParser {
   private:


### PR DESCRIPTION
It looks like https://github.com/jvm-profiling-tools/async-profiler/commit/e89d41de54dd13f3bdf3e18e4d6a37c9e31e7a84 broke the compilation on MacOS.