### PR TITLE
Register natives one-by-one to support partial Java API implementations

### DIFF
--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -144,7 +144,9 @@ void JavaAPI::registerNatives(jvmtiEnv* jvmti, JNIEnv* jni) {
         if (frame[i].method == load || frame[i].method == loadLibrary) {
             jclass profiler_class;
             if (jvmti->GetMethodDeclaringClass(frame[i + 1].method, &profiler_class) == 0) {
-                jni->RegisterNatives(profiler_class, profiler_natives, sizeof(profiler_natives) / sizeof(JNINativeMethod));
+                for (int j = 0; j < sizeof(profiler_natives) / sizeof(JNINativeMethod); j++) {
+                    jni->RegisterNatives(profiler_class, &profiler_natives[j], 1);
+                }
             }
             break;
         }


### PR DESCRIPTION
Otherwise the first missing native declaration in the
Java class will abort registration. This hinders the ability
to add natives to the API without breaking "copy/paste" client
implementations.