### PR TITLE
Allow thread filter to be enabled dynamically via Java API

### DIFF
--- a/src/threadFilter.cpp
+++ b/src/threadFilter.cpp
@@ -94,6 +94,7 @@ void ThreadFilter::add(int thread_id) {
     if (!(__sync_fetch_and_or(&word(b, thread_id), bit) & bit)) {
         atomicInc(_size);
     }
+    _enabled = true;
 }
 
 void ThreadFilter::remove(int thread_id) {

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -116,14 +116,14 @@ void WallClock::stop() {
 
 void WallClock::timerLoop() {
     int self = OS::threadId();
-    ThreadFilter* thread_filter = Profiler::_instance.threadFilter();
-    bool thread_filter_enabled = thread_filter->enabled();
     bool sample_idle_threads = _sample_idle_threads;
 
     ThreadList* thread_list = OS::listThreads();
     long long next_cycle_time = OS::nanotime();
 
     while (_running) {
+        ThreadFilter* thread_filter = Profiler::_instance.threadFilter();
+        bool thread_filter_enabled = thread_filter->enabled();
         if (sample_idle_threads) {
             // Try to keep the wall clock interval stable, regardless of the number of profiled threads
             int estimated_thread_count = thread_filter_enabled ? thread_filter->size() : thread_list->size();


### PR DESCRIPTION
  - Set the `_enabled` flag after adding a thread to the filter.
  - Check the `_enabled` flag on each sample, rather than just
    when commencing the sampling loop.