### PR TITLE
Clean up debug symbols instructions and troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ stack traces.
 ```
 No AllocTracer symbols found. Are JDK debug symbols installed?
 ```
-The OpenJDK debug symbols are an hard requirement for allocation profiling.
+The OpenJDK debug symbols are required for allocation profiling.
 See [Installing Debug Symbols](#installing-debug-symbols) for more details.
 If the error message persists after a successful installation of the debug symbols, it is possible that the JDK was upgraded when installing the debug symbols.
 In this case, profiling any Java process which had started prior to the installation will continue to display this message, since the process had loaded the older version of the JDK which lacked debug symbols.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ names.
 * Does not require writing out a perf.data file for further processing in
 user space scripts.
 
+If you wish to resolve JVM functions, the (debug symbols)[#installing-debug-symbols] are required.
+
 ## ALLOCATION profiling
 
 Instead of detecting CPU-consuming code, the profiler can be configured
@@ -91,7 +93,9 @@ It is completely based on open source technologies and it works with OpenJDK.
 
 The minimum supported JDK version is 7u40 where the TLAB callbacks appeared.
 
-Heap profiler requires HotSpot debug symbols. Oracle JDK already has them
+### Installing Debug Symbols
+
+The allocation profiler requires HotSpot debug symbols. Oracle JDK already has them
 embedded in `libjvm.so`, but in OpenJDK builds they are typically shipped
 in a separate package. For example, to install OpenJDK debug symbols on
 Debian / Ubuntu, run:
@@ -112,7 +116,14 @@ On CentOS, RHEL and some other RPM-based distributions, this could be done with
 On Gentoo the `icedtea` OpenJDK package can be built with the per-package setting
 `FEATURES="nostrip"` to retain symbols.
 
-### Wall-clock profiling
+The `gdb` tool can be used to verify if the debug symbols are properly installed for the `libjvm` library.
+For example on Linux:
+```
+$ gdb $JAVA_HOME/lib/server/libjvm.so
+```
+This command's output will either contain `(no debugging symbols found)` or `Reading symbols from...`.
+
+## Wall-clock profiling
 
 `-e wall` option tells async-profiler to sample all threads equally every given
 period of time regardless of thread status: Running, Sleeping or Blocked.
@@ -488,8 +499,11 @@ stack traces.
 ```
 No AllocTracer symbols found. Are JDK debug symbols installed?
 ```
-It might be needed to install the package with OpenJDK debug symbols.
-See [Allocation profiling](#allocation-profiling) for details.
+The OpenJDK debug symbols are an hard requirement for allocation profiling.
+See [Installing Debug Symbols](#installing-debug-symbols) for more details.
+If the error message persists after a successful installation of the debug symbols, it is possible that the JDK was upgraded when installing the debug symbols.
+In this case, profiling any Java process which had started prior to the installation will continue to display this message, since the process had loaded the older version of the JDK which lacked debug symbols.
+Restarting the affected Java processes should resolve the issue.
 
 ```
 VMStructs unavailable. Unsupported JVM?

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ names.
 * Does not require writing out a perf.data file for further processing in
 user space scripts.
 
-If you wish to resolve frames within `libjvm`, the (debug symbols)[#installing-debug-symbols] are required.
+If you wish to resolve frames within `libjvm`, the [debug symbols](#installing-debug-symbols) are required.
 
 ## ALLOCATION profiling
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ names.
 * Does not require writing out a perf.data file for further processing in
 user space scripts.
 
-If you wish to resolve JVM functions, the (debug symbols)[#installing-debug-symbols] are required.
+If you wish to resolve frames within `libjvm`, the (debug symbols)[#installing-debug-symbols] are required.
 
 ## ALLOCATION profiling
 


### PR DESCRIPTION
I ran into an odd case where I tried to alloc profile a running process, the debug symbols were missing, I installed the debug symbols, the profiling continued to fail. This was because the JDK was upgraded when I installed the debug symbols. I added to the troubleshooting section to spare others the investigative work.

I broke the debug symbol information into a separate subsection for anchoring/linking. I also added note in the CPU section that the debug symbols are needed if one wanted resolve frames within libjvm.so. "Wall-clock profiling" section was promoted since it is not a subsection of "ALLOCATION profiling".