### PR TITLE
Raw PMU events; kprobes & uprobes

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -276,7 +276,8 @@ case $ACTION in
     collect)
         jattach "start,file=$FILE,$OUTPUT$FORMAT$PARAMS"
         echo Profiling for "$DURATION" seconds >&2
-        trap 'set +e; DURATION=0' INT
+        set +e
+        trap 'DURATION=0' INT
 
         while [ "$DURATION" -gt 0 ]; do
             DURATION=$(( DURATION-1 ))
@@ -284,6 +285,7 @@ case $ACTION in
             sleep 1
         done
 
+        set -e
         trap - INT
         echo Done >&2
         jattach "stop,file=$FILE,$OUTPUT$FORMAT"

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -872,7 +872,7 @@ Engine* Profiler::selectEngine(const char* event_name) {
         return &wall_clock;
     } else if (strcmp(event_name, EVENT_ITIMER) == 0) {
         return &itimer;
-    } else if (strchr(event_name, '.') != NULL) {
+    } else if (strchr(event_name, '.') != NULL && strchr(event_name, ':') == NULL) {
         return &instrument;
     } else {
         return &perf_events;


### PR DESCRIPTION
New events to be selected in `-e` option:

- Raw PMU event, e.g. `r4d2` selects `MEM_LOAD_L3_HIT_RETIRED.XSNP_HITM` event, which corresponds to event 0xd2, umask 0x4
- PMU event descriptor, e.g. `cpu/event=0xd2,umask=4/`. The same syntax can be used for uncore and vendor-specific events, e.g. `amd_l3/event=0x01,umask=0x80/`
- Symbolic name of a dynamic PMU event, e.g. `cpu/topdown-fetch-bubbles/`
- kprobe/kretprobe, e.g. `kprobe:do_sys_open`, `kretprobe:do_sys_open`
- uprobe/uretprobe, e.g. `uprobe:/usr/lib64/libc-2.17.so+0x114790`