### PR TITLE
Use time types instead of long.

### DIFF
--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -52,8 +52,8 @@ Error ITimer::start(Arguments& args) {
 
     OS::installSignalHandler(SIGPROF, signalHandler);
 
-    long sec = _interval / 1000000000;
-    long usec = (_interval % 1000000000) / 1000;
+    time_t sec = _interval / 1000000000;
+    suseconds_t usec = (_interval % 1000000000) / 1000;
     struct itimerval tv = {{sec, usec}, {sec, usec}};
     
     if (setitimer(ITIMER_PROF, &tv, NULL) != 0) {


### PR DESCRIPTION
This fixes the build on macOS:

Before:
```
src/itimer.cpp:57:34: error: non-constant-expression cannot be narrowed from type 'long' to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
    struct itimerval tv = {{sec, usec}, {sec, usec}};
                                 ^~~~
src/itimer.cpp:57:34: note: insert an explicit cast to silence this issue
    struct itimerval tv = {{sec, usec}, {sec, usec}};
                                 ^~~~
                                 static_cast<__darwin_suseconds_t>( )
src/itimer.cpp:57:47: error: non-constant-expression cannot be narrowed from type 'long' to '__darwin_suseconds_t' (aka 'int') in initializer list [-Wc++11-narrowing]
    struct itimerval tv = {{sec, usec}, {sec, usec}};
                                              ^~~~
src/itimer.cpp:57:47: note: insert an explicit cast to silence this issue
    struct itimerval tv = {{sec, usec}, {sec, usec}};
                                              ^~~~
                                              static_cast<__darwin_suseconds_t>( )
2 errors generated.
```

This is because on macOS `suseconds_t` is `int`, not `long`.