### PR TITLE
Add feature checking for debug symbols

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -112,6 +112,12 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
         }
     }
 
+    /**
+     * Checks whether a feature is supported by the profiler
+     *
+     * @param feature Profiling feature, see {@link Features}
+     * @return true if the feature is supported
+     */
     @Override
     public boolean check(String feature) {
         return check0(feature);

--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -112,6 +112,11 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
         }
     }
 
+    @Override
+    public boolean check(String feature) {
+        return check0(feature);
+    }
+
     /**
      * Execute an agent-compatible profiling command -
      * the comma-separated list of arguments described in arguments.cpp
@@ -212,4 +217,5 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private native void stop0() throws IllegalStateException;
     private native String execute0(String command) throws IllegalArgumentException, IllegalStateException, IOException;
     private native void filterThread0(Thread thread, boolean enable);
+    private native boolean check0(String feature);
 }

--- a/src/api/one/profiler/AsyncProfilerMXBean.java
+++ b/src/api/one/profiler/AsyncProfilerMXBean.java
@@ -34,6 +34,7 @@ public interface AsyncProfilerMXBean {
 
     long getSamples();
     String getVersion();
+    boolean check(String feature);
 
     String execute(String command) throws IllegalArgumentException, IllegalStateException, java.io.IOException;
 

--- a/src/api/one/profiler/Feature.java
+++ b/src/api/one/profiler/Feature.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package one.profiler;
+
+/**
+ * Features to check for {@link AsyncProfiler#check(String)}
+ */
+public class Feature {
+    public static final String DEBUG_SYMBOLS = "DEBUG_SYMBOLS";
+}

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -154,7 +154,7 @@ static const JNINativeMethod profiler_natives[] = {
     F(execute0,      "(Ljava/lang/String;)Ljava/lang/String;"),
     F(getSamples,    "()J"),
     F(filterThread0, "(Ljava/lang/Thread;Z)V"),
-    F(check0, "(Ljava/lang/String;)Z"),
+    F(check0,        "(Ljava/lang/String;)Z"),
 };
 
 #undef F

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -118,6 +118,33 @@ Java_one_profiler_AsyncProfiler_filterThread0(JNIEnv* env, jobject unused, jthre
     }
 }
 
+extern "C" JNIEXPORT jboolean JNICALL
+Java_one_profiler_AsyncProfiler_check0(JNIEnv* env, jobject unused, jstring featureJava) {
+    const char *feature = env->GetStringUTFChars(featureJava, 0);
+
+    bool result = false;
+    if (strcmp(feature, "DEBUG_SYMBOLS") == 0) {
+        NativeCodeCache* libjvm = VMStructs::libjvm();
+
+        if (libjvm->findSymbolByPrefix("_ZN11AllocTracer27send_allocation_in_new_tlab") != NULL &&
+            libjvm->findSymbolByPrefix("_ZN11AllocTracer28send_allocation_outside_tlab") != NULL) {
+            result = true;
+        } else if (libjvm->findSymbolByPrefix("_ZN11AllocTracer33send_allocation_in_new_tlab_eventE11KlassHandleP8HeapWord") != NULL &&
+                   libjvm->findSymbolByPrefix("_ZN11AllocTracer34send_allocation_outside_tlab_eventE11KlassHandleP8HeapWord") != NULL) {
+            result = true;
+        } else if (libjvm->findSymbolByPrefix("_ZN11AllocTracer33send_allocation_in_new_tlab_event") != NULL &&
+                   libjvm->findSymbolByPrefix("_ZN11AllocTracer34send_allocation_outside_tlab_event") != NULL) {
+            result = true;
+        } else {
+            result = false;
+        }
+    }
+
+    env->ReleaseStringUTFChars(featureJava, feature);
+
+    return result;
+}
+
 
 #define F(name, sig)  {(char*)#name, (char*)sig, (void*)Java_one_profiler_AsyncProfiler_##name}
 
@@ -127,6 +154,7 @@ static const JNINativeMethod profiler_natives[] = {
     F(execute0,      "(Ljava/lang/String;)Ljava/lang/String;"),
     F(getSamples,    "()J"),
     F(filterThread0, "(Ljava/lang/Thread;Z)V"),
+    F(check0, "(Ljava/lang/String;)Z"),
 };
 
 #undef F


### PR DESCRIPTION
I'm not sure how helpful this is, but it's a necessary function that I needed for my application so I thought I'd PR it in case it's something others are interested in.

This PR adds a new `AsyncProfiler.check(String)boolean` method, which can support checking for different built-in features. The only feature check I added initially is checking for debug symbols, as it allows knowing ahead of time whether you'll be able to do allocation profiling.

My C++ is very poor, so I think it may be better to move the debug symbol lookups to their own utility instead of copying and slightly modifying the code from the allocation profiler. Please let me know if/how this should be changed.