### PR TITLE
Recognise JetBrains Runtime as Hotspot

### DIFF
--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -64,7 +64,8 @@ bool VM::init(JavaVM* vm, bool attach) {
     if (_jvmti->GetSystemProperty("java.vm.name", &prop) == 0) {
         bool is_hotspot = strstr(prop, "OpenJDK") != NULL ||
                           strstr(prop, "HotSpot") != NULL ||
-                          strstr(prop, "GraalVM") != NULL;
+                          strstr(prop, "GraalVM") != NULL ||
+                          strstr(prop, "Dynamic Code Evolution") != NULL;
         _jvmti->Deallocate((unsigned char*)prop);
 
         if (is_hotspot && _jvmti->GetSystemProperty("java.vm.version", &prop) == 0) {


### PR DESCRIPTION
JetBrains Runtime set `java.vm.name` property based on kind of the build.
For 'base' JBR `java.vm.name` is set to be `Dynamic Code Evolution 64-Bit Server VM` since it is indeed runtime with DCEVM capabilities. 
Nevertheless, JetBrains Runtime being a fork of OpenJDK is definitely a hotspot. 
There is a another `java.vm.*` property that accurately describe what runtime we are running inside --`java.vm.vendor` .  We always set `java.vm.vendor`  property to `JetBrains s.r.o.`.

This PR adds `JetBrains Runtime` to the list of hotspot runtime that allows async-profiler to use convenient features, e.g.: disabling warnings caused by https://bugs.openjdk.java.net/browse/JDK-8238460