### PR TITLE
 Recognise `DCEVM` as Hotspot

### DIFF
--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -64,7 +64,8 @@ bool VM::init(JavaVM* vm, bool attach) {
     if (_jvmti->GetSystemProperty("java.vm.name", &prop) == 0) {
         bool is_hotspot = strstr(prop, "OpenJDK") != NULL ||
                           strstr(prop, "HotSpot") != NULL ||
-                          strstr(prop, "GraalVM") != NULL;
+                          strstr(prop, "GraalVM") != NULL ||
+                          strstr(prop, "Dynamic Code Evolution") != NULL;
         _jvmti->Deallocate((unsigned char*)prop);
 
         if (is_hotspot && _jvmti->GetSystemProperty("java.vm.version", &prop) == 0) {


### PR DESCRIPTION
An updated version of https://github.com/jvm-profiling-tools/async-profiler/pull/456
We not only report JBR as hotspot, but also vanilla DCEVM, that being a fork of OpenJDK is definitely a hotspot.