### PR TITLE
Default to itimer profiler when perf profiler isn't available

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -884,7 +884,7 @@ Engine* Profiler::selectEngine(const char* event_name) {
     if (event_name == NULL) {
         return &noop_engine;
     } else if (strcmp(event_name, EVENT_CPU) == 0) {
-        return PerfEvents::supported() ? (Engine*)&perf_events : (Engine*)&wall_clock;
+        return PerfEvents::supported() ? (Engine*)&perf_events : (Engine*)&itimer;
     } else if (strcmp(event_name, EVENT_WALL) == 0) {
         return &wall_clock;
     } else if (strcmp(event_name, EVENT_ITIMER) == 0) {


### PR DESCRIPTION
Today, it defaults to wall time profiler since d78e0b3a517593ced9af0fbaa073105f379c228d. This commit doesn't make it clear why that change of behavior, especially on Linux.

It is more useful to switch to itimer as it's behavior is closer to perf sampling interval.