### PR TITLE
Handle OpenJDK C++ Interpreter

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -277,16 +277,13 @@ static bool is_prefix(const char* str, const char* prefix) {
 static bool is_cpp_interpreter_method(const char* mn) {
     if (mn == NULL) return false;
 
-    // These are C++ Interpreter methods from OpenJDK C++ Interpreter:
+    // These are methods from OpenJDK C++ Interpreter:
     //   BytecodeInterpreter::run
     //   ZeroIntepreter::*_entry
     //
-    // It is fine to over-match a little.  Handle both mangled and unmangled
-    // method names, in case the engine feeds us either.
+    // It is fine to over-match a little.
     return is_prefix(mn, "_ZN15ZeroInterpreter9") ||
-           is_prefix(mn, "_ZN19BytecodeInterpreter3run") ||
-           is_prefix(mn, "ZeroInterpreter::") ||
-           is_prefix(mn, "BytecodeInterpreter::run");
+           is_prefix(mn, "_ZN19BytecodeInterpreter3run");
 }
 
 int Profiler::getNativeTrace(Engine* engine, void* ucontext, ASGCT_CallFrame* frames, int tid) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -279,9 +279,11 @@ static bool is_cpp_interpreter_method(const char* mn) {
 
     // These are methods from OpenJDK C++ Interpreter:
     //   BytecodeInterpreter::run
+    //   ZeroIntepreter::main_loop
     //   ZeroIntepreter::*_entry
     //
-    // It is fine to over-match a little.
+    // It is fine to over-match ZeroInterpreter a little to do
+    // fewer tests on this relatively hot path.
     return is_prefix(mn, "_ZN15ZeroInterpreter") ||
            is_prefix(mn, "_ZN19BytecodeInterpreter3run");
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -282,7 +282,7 @@ static bool is_cpp_interpreter_method(const char* mn) {
     //   ZeroIntepreter::*_entry
     //
     // It is fine to over-match a little.
-    return is_prefix(mn, "_ZN15ZeroInterpreter9") ||
+    return is_prefix(mn, "_ZN15ZeroInterpreter") ||
            is_prefix(mn, "_ZN19BytecodeInterpreter3run");
 }
 


### PR DESCRIPTION
This amends async-profiler to handle OpenJDK C++ interpreter frames correctly, which resolves #472. This relies on OpenJDK supporting AGCT in C++ Interpreter: https://github.com/openjdk/jdk/pull/5848.

I think we can just terminate the C stack walk on encountering the C++ Interpreter frame, and leave the rest to AGCT. There is no need to handle the case when AGCT is not supported for C++ Interpreter (which would allegedly lose stack frames here without AGCT covering for us), because the unsupporting VM would just crash when trying to use AGCT. 

Additional testing:
 - [x] Eyeballing flamegraphs on sample benchmarks for OpenJDK x86_64 Zero
 - [x] Checking that current not-AGCT-enabled release Zero VM crashes with `ShouldNotCall` inside Hotspot
 