### PR TITLE
Add 'Engine::onThreadStart' and 'Engine::onThreadEnd' methods

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -32,6 +32,12 @@ Error Engine::start(Arguments& args) {
 void Engine::stop() {
 }
 
+void Engine::onThreadStart(jvmtiEnv *jvmti, JNIEnv *jni, int tid, jthread thread) {
+}
+
+void Engine::onThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, int tid, jthread thread) {
+}
+
 int Engine::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth) {
     const void* pc;
     uintptr_t fp;

--- a/src/engine.h
+++ b/src/engine.h
@@ -17,6 +17,7 @@
 #ifndef _ENGINE_H
 #define _ENGINE_H
 
+#include <jvmti.h>
 #include "arguments.h"
 
 
@@ -36,6 +37,9 @@ class Engine {
     virtual Error check(Arguments& args);
     virtual Error start(Arguments& args);
     virtual void stop();
+
+    virtual void onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread);
+    virtual void onThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread);
 
     virtual int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth);
 

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -40,6 +40,9 @@ class PerfEvents : public Engine {
     Error start(Arguments& args);
     void stop();
 
+    void onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread);
+    void onThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread);
+
     int getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth);
 
     const char* title();

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -770,6 +770,14 @@ void PerfEvents::stop() {
     }
 }
 
+void PerfEvents::onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread) {
+    createForThread(tid);
+}
+
+void PerfEvents::onThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, int tid, jthread thread) {
+    destroyForThread(tid);
+}
+
 int PerfEvents::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth) {
     PerfEvent* event = &_events[tid];
     if (!event->tryLock()) {

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -48,6 +48,12 @@ Error PerfEvents::start(Arguments& args) {
 void PerfEvents::stop() {
 }
 
+void PerfEvents::onThreadStart(jvmtiEnv *jvmti, JNIEnv *jni, int tid, jthread thread) {
+}
+
+void PerfEvents::onThreadEnd(jvmtiEnv *jvmti, JNIEnv *jni, int tid, jthread thread) {
+}
+
 int PerfEvents::getNativeTrace(void* ucontext, int tid, const void** callchain, int max_depth) {
     return 0;
 }

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -124,20 +124,14 @@ void Profiler::onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     int tid = OS::threadId();
     _thread_filter.remove(tid);
     updateThreadName(jvmti, jni, thread);
-
-    if (_engine == &perf_events) {
-        PerfEvents::createForThread(tid);
-    }
+    _engine->onThreadStart(jvmti, jni, tid, thread);
 }
 
 void Profiler::onThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
     int tid = OS::threadId();
     _thread_filter.remove(tid);
     updateThreadName(jvmti, jni, thread);
-
-    if (_engine == &perf_events) {
-        PerfEvents::destroyForThread(tid);
-    }
+    _engine->onThreadEnd(jvmti, jni, tid, thread);
 }
 
 const char* Profiler::asgctError(int code) {


### PR DESCRIPTION
It is useful to propagate `onThreadStart` and `onThreadEnd` events from profiler to engine. It allows a new engine to handle such events. It also simplifies current `Profiler::onThreadStart` and `Profiler::onThreadEnd` implementations.