### PR TITLE
'Error::_message' is std::string now

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -25,7 +25,7 @@
 
 
 // Predefined value that denotes successful operation
-const Error Error::OK(NULL);
+const Error Error::OK("");
 
 // Extra buffer space for expanding file pattern
 const size_t EXTRA_BUF_SIZE = 512;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -17,6 +17,7 @@
 #ifndef _ARGUMENTS_H
 #define _ARGUMENTS_H
 
+#include <string>
 #include <stddef.h>
 
 
@@ -96,20 +97,20 @@ struct Multiplier {
 
 class Error {
   private:
-    const char* _message;
+    std::string _message;
 
   public:
     static const Error OK;
 
-    explicit Error(const char* message) : _message(message) {
+    explicit Error(const std::string& message) : _message(message) {
     }
 
     const char* message() {
-        return _message;
+        return _message.c_str();
     }
 
     operator bool() {
-        return _message != NULL;
+        return !_message.empty();
     }
 };
 


### PR DESCRIPTION
Automatically release string resource in destructor