### PR TITLE
Added option to profile specific CPU

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -45,6 +45,7 @@ usage() {
     echo "  --jfrsync config  synchronize profiler with JFR recording"
     echo "  --fdtransfer      use fdtransfer to serve perf requests"
     echo "                    from the non-privileged target"
+    echo "  --cpu             the cpu to monitor. Defaults to -1."
     echo ""
     echo "<pid> is a numeric process ID of the target JVM"
     echo "      or 'jps' keyword to find running JVM automatically"
@@ -251,6 +252,10 @@ while [ $# -gt 0 ]; do
             ;;
         --safe-mode)
             PARAMS="$PARAMS,safemode=$2"
+            shift
+            ;;
+        --cpu)
+            PARAMS="$PARAMS,cpu=$2"
             shift
             ;;
         [0-9]*)

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -98,6 +98,7 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 //     title=TITLE      - FlameGraph title
 //     minwidth=PCT     - FlameGraph minimum frame width in percent
 //     reverse          - generate stack-reversed FlameGraph / Call tree
+//     cpu=CPU          - the cpu to profile. cpu's are 0 based. (default: -1)
 //
 // It is possible to specify multiple dump options at the same time
 
@@ -114,7 +115,7 @@ Error Arguments::parse(const char* args) {
     }
     strcpy(_buf, args);
 
-    const char* msg = NULL;    
+    const char* msg = NULL;
 
     for (char* arg = strtok(_buf, ","); arg != NULL; arg = strtok(NULL, ",")) {
         char* value = strchr(arg, '=');
@@ -307,6 +308,11 @@ Error Arguments::parse(const char* args) {
 
             CASE("reverse")
                 _reverse = true;
+
+            CASE("cpu")
+                if (value == NULL || (_cpu = atoi(value)) < 0) {
+                    msg = "cpu must >= 0";
+                }
         }
     }
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -160,6 +160,7 @@ class Arguments {
     const char* _title;
     double _minwidth;
     bool _reverse;
+    int _cpu;
 
     Arguments() :
         _buf(NULL),
@@ -195,7 +196,8 @@ class Arguments {
         _end(NULL),
         _title(NULL),
         _minwidth(0),
-        _reverse(false) {
+        _reverse(false),
+        _cpu(-1){
     }
 
     ~Arguments();

--- a/src/perfEvents.h
+++ b/src/perfEvents.h
@@ -50,7 +50,7 @@ class PerfEvents : public Engine {
     static bool supported();
     static const char* getEventName(int event_id);
 
-    static int createForThread(int tid);
+    static int createForThread(int tid, int cpu);
     static void destroyForThread(int tid);
 };
 

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -503,7 +503,7 @@ long PerfEvents::_interval;
 Ring PerfEvents::_ring;
 CStack PerfEvents::_cstack;
 
-int PerfEvents::createForThread(int tid) {
+int PerfEvents::createForThread(int tid, int cpu) {
     if (tid >= _max_events) {
         Log::warn("tid[%d] > pid_max[%d]. Restart profiler after changing pid_max", tid, _max_events);
         return -1;
@@ -557,7 +557,7 @@ int PerfEvents::createForThread(int tid) {
     if (FdTransferClient::hasPeer()) {
         fd = FdTransferClient::requestPerfFd(&tid, &attr);
     } else {
-        fd = syscall(__NR_perf_event_open, &attr, tid, -1, -1, 0);
+        fd = syscall(__NR_perf_event_open, &attr, tid, cpu, -1, 0);
     }
 
     if (fd == -1) {
@@ -747,7 +747,7 @@ Error PerfEvents::start(Arguments& args) {
     bool created = false;
     ThreadList* thread_list = OS::listThreads();
     for (int tid; (tid = thread_list->next()) != -1; ) {
-        if ((err = createForThread(tid)) == 0) {
+        if ((err = createForThread(tid, args._cpu)) == 0) {
             created = true;
         }
     }

--- a/src/perfEvents_macos.cpp
+++ b/src/perfEvents_macos.cpp
@@ -63,7 +63,7 @@ const char* PerfEvents::getEventName(int event_id) {
     return NULL;
 }
 
-int PerfEvents::createForThread(int tid) {
+int PerfEvents::createForThread(int tid, cpu) {
     return -1;
 }
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -120,13 +120,13 @@ void Profiler::addRuntimeStub(const void* address, int length, const char* name)
     CodeHeap::updateBounds(address, (const char*)address + length);
 }
 
-void Profiler::onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
+void Profiler::onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, int cpu) {
     int tid = OS::threadId();
     _thread_filter.remove(tid);
     updateThreadName(jvmti, jni, thread);
 
     if (_engine == &perf_events) {
-        PerfEvents::createForThread(tid);
+        PerfEvents::createForThread(tid, cpu);
     }
 }
 

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -131,7 +131,7 @@ class Profiler {
     void removeJavaMethod(const void* address, jmethodID method);
     void addRuntimeStub(const void* address, int length, const char* name);
 
-    void onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
+    void onThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, int cpu);
     void onThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
 
     const char* asgctError(int code);
@@ -239,8 +239,8 @@ class Profiler {
         instance()->addRuntimeStub(address, length, name);
     }
 
-    static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
-        instance()->onThreadStart(jvmti, jni, thread);
+    static void JNICALL ThreadStart(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread, int cpu) {
+        instance()->onThreadStart(jvmti, jni, thread, cpu);
     }
 
     static void JNICALL ThreadEnd(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {


### PR DESCRIPTION
By default async-profiler will profile all CPU's.

A new option has been added to profile only a specific CPU. This can be used like this:

```
--cpu <cpu>
```