### PR TITLE
Escape backslashes in flamegraph frame names

### DIFF
--- a/src/converter/FlameGraph.java
+++ b/src/converter/FlameGraph.java
@@ -143,7 +143,9 @@ public class FlameGraph {
     private void printFrame(PrintStream out, String title, Frame frame, int level, long x) {
         int type = frameType(title);
         title = stripSuffix(title);
-        title = title.replace("\\", "\\\\");
+        if (title.indexOf('\\') >= 0) {
+            title = title.replace("\\", "\\\\");
+        }
         if (title.indexOf('\'') >= 0) {
             title = title.replace("'", "\\'");
         }

--- a/src/converter/FlameGraph.java
+++ b/src/converter/FlameGraph.java
@@ -143,6 +143,7 @@ public class FlameGraph {
     private void printFrame(PrintStream out, String title, Frame frame, int level, long x) {
         int type = frameType(title);
         title = stripSuffix(title);
+        title = title.replace("\\", "\\\\");
         if (title.indexOf('\'') >= 0) {
             title = title.replace("'", "\\'");
         }


### PR DESCRIPTION
I encountered it while converting collapsed files generated from a NodeJS perf. They include frames named `RegExp:` followed by the regular expression itself, which may contain backslashes. Expressions ending in `\` cause a syntax error because it escapes the closing quote.

This can be demonstrated with the following collapsed file:
```
blabla\ 1
blabla\\ 2
```

on master, the generated HTML fails to display (and Chrome complains about JS syntax error in the console).

On this branch, the graph is displayed correctly.