### PR TITLE
Fail arguments parsing upon unknown argument

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -307,6 +307,9 @@ Error Arguments::parse(const char* args) {
 
             CASE("reverse")
                 _reverse = true;
+
+            } else {
+                msg = "Unknown argument";
         }
     }
 

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -46,6 +46,8 @@ static const Multiplier UNIVERSAL[] = {{'n', 1}, {'u', 1000}, {'m', 1000000}, {'
 
 #define CASE(s)        } else if (arg_hash == HASH(s "            ")) {
 
+#define DEFAULT()      } else {
+
 
 // Parses agent arguments.
 // The format of the string is:
@@ -308,7 +310,7 @@ Error Arguments::parse(const char* args) {
             CASE("reverse")
                 _reverse = true;
 
-            } else {
+            DEFAULT()
                 msg = "Unknown argument";
         }
     }


### PR DESCRIPTION
When using `profiler.sh` this probably can't happen, but for others writing other frontends, this can catch sad errors like typos in passed arguments, which are currently ignored :( Also, it might catch errors in existing frontends, who knows.

It would be nicer if the returned error included the argument name, but I see that the `Error` class expects a long-living `char *` pointer, and does no memory management on its own, so I can't pass a stack buffer (which is deallocated by the point the string is used) or a heap buffer (which will be leaked). Additionally, the `Log` object is not yet initialized, so I can't use it either.
A static string is still better than nothing, hence I'm proposing this PR as is.

~~I can maybe replace `} else {` with `#define DEFAULT` so it looks nicer?~~ done