### PR TITLE
Refactor jattach such that it can be structured as library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ build:
 build/$(LIB_PROFILER_SO): $(SOURCES) $(HEADERS) $(JAVA_HEADERS)
 	$(CXX) $(CXXFLAGS) -DPROFILER_VERSION=\"$(PROFILER_VERSION)\" $(INCLUDES) -fPIC -shared -o $@ $(SOURCES) $(LIBS)
 
-build/$(JATTACH): src/jattach/*.c src/jattach/*.h
+build/$(JATTACH): src/jattach/*.c src/jattach/*.h build
 	$(CC) $(CFLAGS) -DJATTACH_VERSION=\"$(PROFILER_VERSION)-ap\" -o $@ src/jattach/*.c
 
 build/fdtransfer: src/fdtransfer/*.cpp src/fdtransfer/*.h src/jattach/psutil.c src/jattach/psutil.h

--- a/src/jattach/jattach.c
+++ b/src/jattach/jattach.c
@@ -15,7 +15,6 @@
  */
 
 #include <stdio.h>
-#include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>
 #include "psutil.h"
@@ -62,27 +61,4 @@ int jattach(int pid, int argc, char** argv) {
     } else {
         return jattach_hotspot(pid, nspid, argc, argv);
     }
-}
-
-int main(int argc, char** argv) {
-    if (argc < 3) {
-        printf("jattach " JATTACH_VERSION " built on " __DATE__ "\n"
-               "Copyright 2021 Andrei Pangin\n"
-               "\n"
-               "Usage: jattach <pid> <cmd> [args ...]\n"
-               "\n"
-               "Commands:\n"
-               "    load  threaddump   dumpheap  setflag    properties\n"
-               "    jcmd  inspectheap  datadump  printflag  agentProperties\n"
-               );
-        return 1;
-    }
-
-    int pid = atoi(argv[1]);
-    if (pid <= 0) {
-        fprintf(stderr, "%s is not a valid process ID\n", argv[1]);
-        return 1;
-    }
-
-    return jattach(pid, argc - 2, argv + 2);
 }

--- a/src/jattach/main.c
+++ b/src/jattach/main.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Andrei Pangin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int jattach(int pid, int argc, char** argv);
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        printf("jattach " JATTACH_VERSION " built on " __DATE__ "\n"
+               "Copyright 2021 Andrei Pangin\n"
+               "\n"
+               "Usage: jattach <pid> <cmd> [args ...]\n"
+               "\n"
+               "Commands:\n"
+               "    load  threaddump   dumpheap  setflag    properties\n"
+               "    jcmd  inspectheap  datadump  printflag  agentProperties\n"
+               );
+        return 1;
+    }
+
+    int pid = atoi(argv[1]);
+    if (pid <= 0) {
+        fprintf(stderr, "%s is not a valid process ID\n", argv[1]);
+        return 1;
+    }
+
+    return jattach(pid, argc - 2, argv + 2);
+}


### PR DESCRIPTION
Refactor jattach such that it can be more easily used as a library in other open source projects. Essentially, we just pull main() into its own file.

Signed-off-by: Pete Stevenson <jps@pixielabs.ai>