### PR TITLE
Remove double close() call

### DIFF
--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -378,7 +378,6 @@ void Symbols::parseKernelSymbols(NativeCodeCache* cc) {
     }
 
     fclose(f);
-    close(fd);
 }
 
 void Symbols::parseLibraries(NativeCodeCache** array, volatile int& count, int size, bool kernel_symbols) {


### PR DESCRIPTION
fclose() on an fdopen()ed file closes the underlying file descriptor.

Tested with this program:
```
#include <stdio.h>
#include <sys/stat.h>
#include <sys/types.h>
#include <unistd.h>
#include <fcntl.h>

int main(void) {
    int fd = open("/dev/null", O_RDONLY);
    FILE *fp = fdopen(fd, "r");

    fclose(fp);
    close(fd);
}
```

stracing it results in:
```
openat(AT_FDCWD, "/dev/null", O_RDONLY) = 3
fcntl(3, F_GETFL)                       = 0x8000 (flags O_RDONLY|O_LARGEFILE)
brk(NULL)                               = 0x562a0bb5d000
brk(0x562a0bb7e000)                     = 0x562a0bb7e000
close(3)                                = 0
close(3)                                = -1 EBADF (Bad file descriptor)
```

Also from `fdopen(3)`: `The file descriptor is not dup'ed, and will be closed when the stream created by fdopen() is closed.`

Bug is present since #411 (v2.5). Sorry for that :(

The race here is unlikely but present, for the first time AP starts and loads the kernel symbols, there is a slight chance that another thread receives the same fd number from some `open` `accept` etc, and then we close it for that thread.