### PR TITLE
Incremental jfr

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -328,6 +328,10 @@ Error Arguments::parse(const char* args) {
         if (_output == OUTPUT_SVG) {
             return Error("SVG format is obsolete, use .html for FlameGraph");
         }
+        if (_output == OUTPUT_IJFR) {
+            _output = OUTPUT_JFR;
+            _jfr_options |= INCREMENTAL;
+        }
         _dump_traces = 100;
         _dump_flat = 200;
     }
@@ -393,6 +397,8 @@ Output Arguments::detectOutputFormat(const char* file) {
             return OUTPUT_FLAMEGRAPH;
         } else if (strcmp(ext, ".jfr") == 0) {
             return OUTPUT_JFR;
+        } else if (strcmp(ext, ".ijfr") == 0) {
+            return OUTPUT_IJFR;
         } else if (strcmp(ext, ".collapsed") == 0 || strcmp(ext, ".folded") == 0) {
             return OUTPUT_COLLAPSED;
         } else if (strcmp(ext, ".svg") == 0) {

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -75,7 +75,8 @@ enum Output {
     OUTPUT_COLLAPSED,
     OUTPUT_FLAMEGRAPH,
     OUTPUT_TREE,
-    OUTPUT_JFR
+    OUTPUT_JFR,
+    OUTPUT_IJFR
 };
 
 enum JfrOption {
@@ -83,6 +84,7 @@ enum JfrOption {
     NO_SYSTEM_PROPS = 0x2,
     NO_NATIVE_LIBS  = 0x4,
     NO_CPU_LOAD     = 0x8,
+    INCREMENTAL     = 0x10,
 
     JFR_SYNC_OPTS   = NO_SYSTEM_INFO | NO_SYSTEM_PROPS | NO_NATIVE_LIBS | NO_CPU_LOAD
 };

--- a/src/callTraceStorage.cpp
+++ b/src/callTraceStorage.cpp
@@ -22,7 +22,6 @@
 static const u32 INITIAL_CAPACITY = 65536;
 static const u32 CALL_TRACE_CHUNK = 8 * 1024 * 1024;
 static const u32 OVERFLOW_TRACE_ID = 0x7fffffff;
-static const u64 INCREMENTAL_MARKER = 0x8000000000000000ULL;
 
 
 class LongHashTable {
@@ -116,14 +115,23 @@ void CallTraceStorage::collectTraces(std::map<u32, CallTrace*>& map, bool increm
         u32 capacity = table->capacity();
 
         for (u32 slot = 0; slot < capacity; slot++) {
-            u64 samples = loadAcquire(values[slot].samples);
-            if (keys[slot] == 0 || samples == 0) {
+            if (keys[slot] == 0) {
                 continue;
             }
-            if (incremental && (samples & INCREMENTAL_MARKER)) {
+            CallTraceSample& callSample = values[slot];
+            if (callSample.incremental_marker) {
                 continue;
             }
-            values[slot].samples = incremental ? INCREMENTAL_MARKER : 0;
+            u64 samples = loadAcquire(callSample.samples);
+            if (samples == 0) {
+                continue;
+            }
+            if (incremental) {
+                values[slot].incremental_marker = true;
+            } else {
+                // Reset samples to avoid duplication of call traces between JFR chunks
+                values[slot].samples = 0;
+            }
             map[capacity - (INITIAL_CAPACITY - 1) + slot] = values[slot].trace;
         }
     }

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -65,7 +65,7 @@ class CallTraceStorage {
     ~CallTraceStorage();
 
     void clear();
-    void collectTraces(std::map<u32, CallTrace*>& map);
+    void collectTraces(std::map<u32, CallTrace*>& map, bool incremental);
     void collectSamples(std::vector<CallTraceSample*>& samples);
     void collectSamples(std::map<u64, CallTraceSample>& map);
 

--- a/src/callTraceStorage.h
+++ b/src/callTraceStorage.h
@@ -35,6 +35,7 @@ struct CallTraceSample {
     CallTrace* trace;
     u64 samples;
     u64 counter;
+    bool incremental_marker;
 
     CallTraceSample& operator+=(const CallTraceSample& s) {
         trace = s.trace;

--- a/src/dictionary.cpp
+++ b/src/dictionary.cpp
@@ -76,6 +76,10 @@ unsigned int Dictionary::lookup(const char* key) {
 }
 
 unsigned int Dictionary::lookup(const char* key, size_t length) {
+    return lookup(key, length, false);
+}
+
+unsigned int Dictionary::lookup(const char* key, size_t length, bool mark_new) {
     DictTable* table = _table;
     unsigned int h = hash(key, length);
 
@@ -85,7 +89,8 @@ unsigned int Dictionary::lookup(const char* key, size_t length) {
             if (row->keys[c] == NULL) {
                 char* new_key = allocateKey(key, length);
                 if (__sync_bool_compare_and_swap(&row->keys[c], NULL, new_key)) {
-                    return table->index(h % ROWS, c);
+                    unsigned int result = table->index(h % ROWS, c);
+                    return mark_new ? (result | 0x80000000) : result;
                 }
                 free(new_key);
             }

--- a/src/dictionary.h
+++ b/src/dictionary.h
@@ -63,6 +63,7 @@ class Dictionary {
 
     unsigned int lookup(const char* key);
     unsigned int lookup(const char* key, size_t length);
+    unsigned int lookup(const char* key, size_t length, bool mark_new);
 
     void collect(std::map<unsigned int, const char*>& map);
 };


### PR DESCRIPTION
This PR introduces a file format that really close to the JFR but has less overhead when flushing chunks.
Main idea is to dump only new stacktaces/methods/constants/etc. File format is compatible with jfr2flame tool but incompatible with FR.
To try it just use -f somefilename.ijfr. Then jfr2flame converter must be used to get flame graph. It can be run without profiling stop.