### PR TITLE
Build flame graph from events in time range

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -97,6 +97,9 @@ fdtransfer() {
 }
 
 jattach() {
+    if [ -n "$VERBOSE" ]; then
+      echo Executing: "$JATTACH" "$PID" load "$PROFILER" true "$1,log=$LOG"
+    fi
     set +e
     "$JATTACH" "$PID" load "$PROFILER" true "$1,log=$LOG" > /dev/null
     RET=$?
@@ -139,6 +142,7 @@ OUTPUT=""
 FORMAT=""
 PARAMS=""
 PID=""
+VERBOSE=""
 
 while [ $# -gt 0 ]; do
     case $1 in
@@ -260,6 +264,9 @@ while [ $# -gt 0 ]; do
         --safe-mode)
             PARAMS="$PARAMS,safemode=$2"
             shift
+            ;;
+        --verbose)
+            VERBOSE=1
             ;;
         [0-9]*)
             PID="$1"

--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -30,6 +30,11 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private AsyncProfiler() {
     }
 
+    // Assume it was loaded with -agentpath
+    public static AsyncProfiler getPreloadedInstance() {
+        instance = new AsyncProfiler();
+        return instance;
+    }
     public static AsyncProfiler getInstance() {
         return getInstance(null);
     }

--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -30,11 +30,6 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     private AsyncProfiler() {
     }
 
-    // Assume it was loaded with -agentpath
-    public static AsyncProfiler getPreloadedInstance() {
-        instance = new AsyncProfiler();
-        return instance;
-    }
     public static AsyncProfiler getInstance() {
         return getInstance(null);
     }
@@ -44,13 +39,19 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
             return instance;
         }
 
-        if (libPath == null) {
-            System.loadLibrary("asyncProfiler");
-        } else {
-            System.load(libPath);
+        AsyncProfiler ap = new AsyncProfiler();
+
+        try {
+            ap.getVersion();
+        } catch (UnsatisfiedLinkError e) {
+            if (libPath == null) {
+                System.loadLibrary("asyncProfiler");
+            } else {
+                System.load(libPath);
+            }
         }
 
-        instance = new AsyncProfiler();
+        instance = ap;
         return instance;
     }
 

--- a/src/converter/ConverterArgs.java
+++ b/src/converter/ConverterArgs.java
@@ -1,0 +1,38 @@
+public class ConverterArgs {
+    public String title = "Flame Graph";
+    public boolean reverse;
+    public double minwidth;
+    public int skip;
+    public String input;
+    public String output;
+    public long t1 = Long.MIN_VALUE;
+    public long t2 = Long.MAX_VALUE;
+    public boolean collapsed = false;
+
+    ConverterArgs(String... args) {
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            if (!arg.startsWith("--") && !arg.isEmpty()) {
+                if (input == null) {
+                    input = arg;
+                } else {
+                    output = arg;
+                }
+            } else if (arg.equals("--title")) {
+                title = args[++i];
+            } else if (arg.equals("--reverse")) {
+                reverse = true;
+            } else if (arg.equals("--minwidth")) {
+                minwidth = Double.parseDouble(args[++i]);
+            } else if (arg.equals("--skip")) {
+                skip = Integer.parseInt(args[++i]);
+            } else if (arg.equals("--t1")) {
+                t1 = Long.parseLong(args[++i]);
+            } else if (arg.equals("--t2")) {
+                t2 = Long.parseLong(args[++i]);
+            } else if (arg.equals("--collapsed")) {
+                collapsed = true;
+            }
+        }
+    }
+}

--- a/src/converter/FlameGraph.java
+++ b/src/converter/FlameGraph.java
@@ -33,6 +33,9 @@ public class FlameGraph {
     public int skip;
     public String input;
     public String output;
+    public long t1 = Long.MIN_VALUE;
+    public long t2 = Long.MAX_VALUE;
+
 
     private final Frame root = new Frame();
     private int depth;
@@ -55,6 +58,10 @@ public class FlameGraph {
                 minwidth = Double.parseDouble(args[++i]);
             } else if (arg.equals("--skip")) {
                 skip = Integer.parseInt(args[++i]);
+            } else if (arg.equals("--t1")) {
+                t1 = Long.parseLong(args[++i]);
+            } else if (arg.equals("--t2")) {
+                t2 = Long.parseLong(args[++i]);
             }
         }
     }

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -83,6 +83,10 @@ public class JfrReader implements Closeable {
         }
     }
 
+    public void rewind() throws IOException {
+        seek(0);
+    }
+
     @Override
     public void close() throws IOException {
         ch.close();


### PR DESCRIPTION
It's useful sometimes to examine the profile within a specific time range.  This requires knowing the start time of the recording before aggregating, and it seems that the easiest way to do this is to iterate over all the events to find the earliest.  I tried extracting the `ActiveRecording` metadata, but the values didn't make sense - strings were plausible, but durations were too long.  It also seems a little weird to have the time range extracted via the `FlameGraph` constructor, but, again, it was easiest.