### PR TITLE
Look in plt sections for the global offset table too

### DIFF
--- a/src/symbols_linux.cpp
+++ b/src/symbols_linux.cpp
@@ -228,7 +228,8 @@ loaded:
 
         // Find the bounds of the Global Offset Table
         ElfSection* got = findSection(SHT_PROGBITS, ".got.plt");
-        if (got != NULL || (got = findSection(SHT_PROGBITS, ".got")) != NULL) {
+        if (got != NULL || (got = findSection(SHT_NOBITS, ".plt")) != NULL ||
+            (got = findSection(SHT_PROGBITS, ".got")) != NULL) {
             _cc->setGlobalOffsetTable(_base + got->sh_addr, got->sh_size);
         }
 


### PR DESCRIPTION
Hi Andrei,
unfortunately the 'Patch Global Offset Table to hook libc functions' change broke the PPC64le port. The symbol is located in .plt on PPC64le. The fix is simple, and should not brake anything else. I did it together with my colleague Johannes (@parttimenerd) who will continue to help maintaining the port.