### PR TITLE
Add loglevel argument

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -254,6 +254,12 @@ Error Arguments::parse(const char* args) {
             CASE("log")
                 _log = value == NULL || value[0] == 0 ? NULL : value;
 
+            CASE("loglevel")
+                if (value == NULL || value[0] == 0) {
+                    msg = "loglevel must not be empty";
+                }
+                _loglevel = value;
+
             CASE("fdtransfer")
                 _fdtransfer = true;
                 _fdtransfer_path = value;

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -142,6 +142,7 @@ class Arguments {
     int _safe_mode;
     const char* _file;
     const char* _log;
+    const char* _loglevel;
     const char* _filter;
     int _include;
     int _exclude;
@@ -182,6 +183,7 @@ class Arguments {
         _safe_mode(0),
         _file(NULL),
         _log(NULL),
+        _loglevel(NULL),
         _filter(NULL),
         _include(0),
         _exclude(0),

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -67,6 +67,8 @@ Java_one_profiler_AsyncProfiler_execute0(JNIEnv* env, jobject unused, jstring co
         return NULL;
     }
 
+    Log::open(args._log, args._loglevel);
+
     if (!args.hasOutputFile()) {
         std::ostringstream out;
         error = Profiler::instance()->runInternal(args, out);

--- a/src/log.h
+++ b/src/log.h
@@ -26,9 +26,7 @@
 #define ATTR_FORMAT
 #endif
 
-
 enum LogLevel {
-    LOG_NONE,
     LOG_TRACE,
     LOG_DEBUG,
     LOG_INFO,
@@ -36,19 +34,21 @@ enum LogLevel {
     LOG_ERROR
 };
 
-
 class Log {
   private:
     static FILE* _file;
+    static LogLevel _level;
 
   public:
     static const char* const LEVEL_NAME[];
 
-    static void open(const char* file_name);
+    static void open(const char* file_name, const char *level);
     static void close();
 
     static void log(LogLevel level, const char* msg, va_list args);
 
+    static void ATTR_FORMAT trace(const char* msg, ...);
+    static void ATTR_FORMAT debug(const char* msg, ...);
     static void ATTR_FORMAT info(const char* msg, ...);
     static void ATTR_FORMAT warn(const char* msg, ...);
     static void ATTR_FORMAT error(const char* msg, ...);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -329,7 +329,7 @@ jvmtiError VM::RetransformClassesHook(jvmtiEnv* jvmti, jint class_count, const j
 extern "C" DLLEXPORT jint JNICALL
 Agent_OnLoad(JavaVM* vm, char* options, void* reserved) {
     Error error = _agent_args.parse(options);
-    Log::open(_agent_args._log);
+    Log::open(_agent_args._log, _agent_args._loglevel);
     if (error) {
         Log::error("%s", error.message());
         return ARGUMENTS_ERROR;
@@ -347,7 +347,7 @@ extern "C" DLLEXPORT jint JNICALL
 Agent_OnAttach(JavaVM* vm, char* options, void* reserved) {
     Arguments args(true);
     Error error = args.parse(options);
-    Log::open(args._log);
+    Log::open(args._log, args._loglevel);
     if (error) {
         Log::error("%s", error.message());
         return ARGUMENTS_ERROR;


### PR DESCRIPTION
It allows to set the minimal log level to output. This is particularely
helpful if you're using async-profiler in production and where you don't
want to clubber your output with not always relevant log information.