### PR TITLE
Generate randomized fdtransfer path per async-profiler invocation

### DIFF
--- a/profiler.sh
+++ b/profiler.sh
@@ -93,7 +93,7 @@ check_if_terminated() {
 
 fdtransfer() {
     if [ "$USE_FDTRANSFER" = "true" ]; then
-        FDTRANSFER_PATH="@async-profiler-$PID-$(od -An -N3 -i /dev/random | xargs)"
+        FDTRANSFER_PATH="@async-profiler-$(od -An -N3 -i /dev/random | xargs)"
         PARAMS="$PARAMS,fdtransfer=$FDTRANSFER_PATH"
         "$FDTRANSFER" "$FDTRANSFER_PATH" "$PID"
     fi

--- a/profiler.sh
+++ b/profiler.sh
@@ -93,7 +93,9 @@ check_if_terminated() {
 
 fdtransfer() {
     if [ "$USE_FDTRANSFER" = "true" ]; then
-        "$FDTRANSFER" "$PID"
+        FDTRANSFER_PATH="@async-profiler-$PID-$(od -An -N3 -i /dev/random | xargs)"
+        PARAMS="$PARAMS,fdtransfer=$FDTRANSFER_PATH"
+        "$FDTRANSFER" "$FDTRANSFER_PATH" "$PID"
     fi
 }
 
@@ -131,6 +133,7 @@ SCRIPT_DIR="$(cd "$(dirname "$SCRIPT_BIN")" > /dev/null 2>&1; pwd -P)"
 JATTACH=$SCRIPT_DIR/build/jattach
 FDTRANSFER=$SCRIPT_DIR/build/fdtransfer
 USE_FDTRANSFER="false"
+FDTRANSFER_PATH=""
 PROFILER=$SCRIPT_DIR/build/libasyncProfiler.so
 ACTION="collect"
 DURATION="60"
@@ -259,7 +262,6 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --fdtransfer)
-            PARAMS="$PARAMS,fdtransfer"
             USE_FDTRANSFER="true"
             ;;
         --safe-mode)

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -271,6 +271,9 @@ Error Arguments::parse(const char* args) {
 
             CASE("fdtransfer")
                 _fdtransfer = true;
+                if (value == NULL) {
+                    msg ="fdtransfer path must not be empty";
+                }
                 _fdtransfer_path = value;
 
             // Filters

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -271,8 +271,8 @@ Error Arguments::parse(const char* args) {
 
             CASE("fdtransfer")
                 _fdtransfer = true;
-                if (value == NULL) {
-                    msg ="fdtransfer path must not be empty";
+                if (value == NULL || value[0] == 0) {
+                    msg = "fdtransfer path must not be empty";
                 }
                 _fdtransfer_path = value;
 

--- a/src/fdtransfer/fdtransfer.h
+++ b/src/fdtransfer/fdtransfer.h
@@ -56,28 +56,15 @@ struct perf_fd_response {
     int tid;
 };
 
-
-static inline bool socketPathForPid(int pid, struct sockaddr_un *sun, socklen_t *addrlen) {
-    sun->sun_path[0] = '\0';
-    const int max_size = sizeof(sun->sun_path) - 1;
-    const int path_len = snprintf(sun->sun_path + 1, max_size, "async-profiler-%d", pid);
-    if (path_len > max_size) {
-        return false;
-    }
-
-    sun->sun_family = AF_UNIX;
-    // +1 for the first \0 byte
-    *addrlen = sizeof(*sun) - (sizeof(sun->sun_path) - (path_len + 1));
-
-    return true;
-}
-
 static inline bool socketPath(const char *path, struct sockaddr_un *sun, socklen_t *addrlen) {
     const int path_len = strlen(path);
     if (path_len > sizeof(sun->sun_path)) {
         return false;
     }
     memcpy(sun->sun_path, path, path_len);
+    if (sun->sun_path[0] == '@') {
+        sun->sun_path[0] = '\0';
+    }
 
     sun->sun_family = AF_UNIX;
     *addrlen = sizeof(*sun) - (sizeof(sun->sun_path) - path_len);

--- a/src/fdtransfer/fdtransferServer.cpp
+++ b/src/fdtransfer/fdtransferServer.cpp
@@ -293,9 +293,12 @@ static int single_pid_server(int pid, const char *path) {
     // Create the server before forking, so w're ready to accept connections once our parent
     // exits.
 
-    if (enter_ns(pid, "net") == -1) {
-        fprintf(stderr, "Failed to enter the net NS of target process %d\n", pid);
-        return 1;
+    // Abstract namespace UDS requires us to move network namespace.
+    if (sun.sun_path[0] == '\0') {
+        if (enter_ns(pid, "net") == -1) {
+            fprintf(stderr, "Failed to enter the net NS of target process %d\n", pid);
+            return 1;
+        }
     }
 
     if (!FdTransferServer::bindServer(&sun, addrlen, 10)) {

--- a/src/fdtransfer/fdtransferServer.cpp
+++ b/src/fdtransfer/fdtransferServer.cpp
@@ -68,7 +68,13 @@ bool FdTransferServer::bindServer(struct sockaddr_un *sun, socklen_t addrlen, in
         }
     }
 
-    if (bind(_server, (const struct sockaddr*)sun, addrlen) < 0 || listen(_server, 1) < 0) {
+    if (bind(_server, (const struct sockaddr*)sun, addrlen) < 0) {
+        perror("FdTransfer bind()");
+        close(_server);
+        return false;
+    }
+
+    if (listen(_server, 1) < 0) {
         perror("FdTransfer listen()");
         close(_server);
         return false;
@@ -267,7 +273,7 @@ bool FdTransferServer::sendFd(int fd, struct fd_response *resp, size_t resp_size
     return true;
 }
 
-static int single_pid_server(int pid) {
+static int single_pid_server(int pid, const char *path) {
     // get its nspid prior to moving to its PID namespace.
     int nspid;
     uid_t _target_uid;
@@ -279,7 +285,7 @@ static int single_pid_server(int pid) {
 
     struct sockaddr_un sun;
     socklen_t addrlen;
-    if (!socketPathForPid(nspid, &sun, &addrlen)) {
+    if (!socketPath(path, &sun, &addrlen)) {
         fprintf(stderr, "Path too long\n");
         return 1;
     }
@@ -360,18 +366,19 @@ static int path_server(const char *path) {
 }
 
 int main(int argc, const char** argv) {
-    if (argc != 2) {
-        fprintf(stderr, "Usage: %s <pid>|<path>\n", argv[0]);
+    int pid = 0;
+    if (argc == 3) {
+        pid = atoi(argv[2]);
+    } else if (argc != 2) {
+        fprintf(stderr, "Usage: %s <path> [<pid>]\n", argv[0]);
         return 1;
     }
 
-    int pid = atoi(argv[1]);
     // 2 modes:
-    // pid == 0 - bind on a path and accept requests forever, from any PID, until being killed
-    // pid != 0 - bind on an abstract namespace UDS for that PID, accept requests only from that PID
-    //            until the single connection is closed.
+    // pid is not given - bind on a path and accept requests forever, from any PID, until being killed.
+    // pid is given     - bind on an path for that PID, accept requests only from that PID until the single connection is closed.
     if (pid != 0) {
-        return single_pid_server(pid);
+        return single_pid_server(pid, argv[1]);
     } else {
         return path_server(argv[1]);
     }

--- a/src/fdtransferClient.h
+++ b/src/fdtransferClient.h
@@ -28,7 +28,7 @@ class FdTransferClient {
     static int recvFd(unsigned int request_id, struct fd_response *resp, size_t resp_size);
 
   public:
-    static bool connectToServer(const char *path, int pid);
+    static bool connectToServer(const char *path);
     static bool hasPeer() { return _peer != -1; }
     static void closePeer() {
         if (_peer != -1) {
@@ -45,7 +45,7 @@ class FdTransferClient {
 
 class FdTransferClient {
   public:
-    static bool connectToServer(const char *path, int pid) { return false; }
+    static bool connectToServer(const char *path) { return false; }
     static bool hasPeer() { return false; }
     static void closePeer() { }
 };

--- a/src/fdtransferClient_linux.cpp
+++ b/src/fdtransferClient_linux.cpp
@@ -31,7 +31,7 @@
 
 int FdTransferClient::_peer = -1;
 
-bool FdTransferClient::connectToServer(const char *path, int pid) {
+bool FdTransferClient::connectToServer(const char *path) {
     closePeer();
 
     _peer = socket(AF_UNIX, SOCK_SEQPACKET, 0);
@@ -42,14 +42,8 @@ bool FdTransferClient::connectToServer(const char *path, int pid) {
 
     struct sockaddr_un sun;
     socklen_t addrlen;
-    if (path != NULL) {
-        if (!socketPath(path, &sun, &addrlen)) {
-            return false;
-        }
-    } else {
-        if (!socketPathForPid(pid, &sun, &addrlen)) {
-            return false;
-        }
+    if (!socketPath(path, &sun, &addrlen)) {
+        return false;
     }
 
     // Do not block for more than 10 seconds when waiting for a response

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -924,7 +924,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     }
 
     if (args._fdtransfer) {
-        if (!FdTransferClient::connectToServer(args._fdtransfer_path, OS::processId())) {
+        if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
             return Error("Failed to initialize FdTransferClient");
         }
     }


### PR DESCRIPTION
Closes: #634

This solves the problem described in #634.

I sanity-tested it by running `for p in $(pgrep java); do sudo ./profiler.sh -d 10 -e cpu -t -f xxx-$p.html -a -o flamegraph $p -i 50us --fdtransfer & ; done` on a system with 2 containerized Java apps; both are the same PID in their PID namespace. On `master`, it fails with `FdTransfer listen(): Address already in use`. On this branch, it passes.