### PR TITLE
Adjust 'j9thread_self' lookup code

### DIFF
--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -138,7 +138,7 @@ bool VM::init(JavaVM* vm, bool attach) {
     Profiler* profiler = Profiler::instance();
     profiler->updateSymbols(false);
 
-    _openj9 = !is_hotspot && J9Ext::initialize(_jvmti, profiler->resolveSymbol("j9thread_self"));
+    _openj9 = !is_hotspot && J9Ext::initialize(_jvmti, profiler->resolveSymbol("j9thread_self*"));
     _can_sample_objects = !is_hotspot || hotspot_version() >= 11;
 
     CodeCache* lib = isOpenJ9()


### PR DESCRIPTION
For OpenJ9 distributions and OpenJDK17+ the current integration is not working properly.

The reason is that the `j9thread_self` symbol was renamed to `j9thread_self@plt` in more recent versions JDK versions. This lead the detection mechanism to fail and the integration not work.

The proposed fix is very simple - just lookup the symbol as `j9thread_self*` to allow the suffix.

With the fix in place the integration works properly once again - tested for Semeru distributions of OpenJDK 17 (17.0.4.1) and OpenJDK 18 (18.0.2).