### PR TITLE
Allow to set Bytecode version for Java compile in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,10 @@ MERGE=true
 
 JAVAC=$(JAVA_HOME)/bin/javac
 JAR=$(JAVA_HOME)/bin/jar
-JAVAC_OPTIONS=-source 7 -target 7 -Xlint:-options
+ifeq ($(JAVAC_RELEASE_VERSION),)
+  export JAVAC_RELEASE_VERSION=7
+endif
+JAVAC_OPTIONS=-source $(JAVAC_RELEASE_VERSION) -target $(JAVAC_RELEASE_VERSION) -Xlint:-options
 
 SOURCES := $(wildcard src/*.cpp)
 HEADERS := $(wildcard src/*.h src/fdtransfer/*.h)

--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,8 @@ MERGE=true
 
 JAVAC=$(JAVA_HOME)/bin/javac
 JAR=$(JAVA_HOME)/bin/jar
-ifeq ($(JAVAC_RELEASE_VERSION),)
-  export JAVAC_RELEASE_VERSION=7
-endif
-JAVAC_OPTIONS=-source $(JAVAC_RELEASE_VERSION) -target $(JAVAC_RELEASE_VERSION) -Xlint:-options
+JAVA_TARGET=7
+JAVAC_OPTIONS=-source $(JAVA_TARGET) -target $(JAVA_TARGET) -Xlint:-options
 
 SOURCES := $(wildcard src/*.cpp)
 HEADERS := $(wildcard src/*.h src/fdtransfer/*.h)

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ and then run `make`. GCC is required. After building, the profiler agent binary
 will be in the `build` subdirectory. Additionally, a small application `jattach`
 that can load the agent into the target process will also be compiled to the
 `build` subdirectory. If the build fails due to
-`Source option 7 is no longer supported. Use 8 or later.`, use `make JAVAC_RELEASE_VERSION=8`.
+`Source option 7 is no longer supported. Use 8 or later.`, use `make JAVAC_TARGET=8`.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ and then run `make`. GCC is required. After building, the profiler agent binary
 will be in the `build` subdirectory. Additionally, a small application `jattach`
 that can load the agent into the target process will also be compiled to the
 `build` subdirectory. If the build fails due to
-`Source option 7 is no longer supported. Use 8 or later.`, use `make JAVAC_TARGET=8`.
+`Source option 7 is no longer supported. Use 8 or later.`, use `make JAVA_TARGET=8`.
 
 ## Basic Usage
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ Make sure the `JAVA_HOME` environment variable points to your JDK installation,
 and then run `make`. GCC is required. After building, the profiler agent binary
 will be in the `build` subdirectory. Additionally, a small application `jattach`
 that can load the agent into the target process will also be compiled to the
-`build` subdirectory.
+`build` subdirectory. If the build fails due to
+`Source option 7 is no longer supported. Use 8 or later.`, use `make JAVAC_RELEASE_VERSION=8`.
 
 ## Basic Usage
 


### PR DESCRIPTION
Reintroduces the `JAVAC_RELEASE_VERSION` to allow developers to specify the Java bytecode version. The rational is that the minimally configurable byte code version goes from 7 to 8 in the JDK 20. This change allows building async-profiler with these JDKs too by using `make JAVAC_RELEASE_VERSION=8`, this his helpful when developing profiling APIs in the JDK.

This is related to #423, but just setting the bytecode version to 8 would be hard to justify as Azul supports Java 7 till 2027.