### PR TITLE
Increase frame buf size

### DIFF
--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -188,7 +188,7 @@ char* FrameName::javaMethodName(jmethodID method) {
         result = javaClassName(class_name + 1, strlen(class_name) - 2, _style);
         strcat(result, ".");
         strcat(result, method_name);
-        if (_style & STYLE_SIGNATURES) strcat(result, truncate(method_sig, 255));
+        if (_style & STYLE_SIGNATURES) strcat(result, truncate(method_sig, sizeof(_buf) - strlen(result) - 1));
     } else {
         snprintf(_buf, sizeof(_buf) - 1, "[jvmtiError %d]", err);
         result = _buf;

--- a/src/frameName.h
+++ b/src/frameName.h
@@ -68,7 +68,7 @@ class FrameName {
     ClassMap _class_names;
     std::vector<Matcher> _include;
     std::vector<Matcher> _exclude;
-    char _buf[800];  // must be large enough for class name + method name + method signature
+    char _buf[1024];  // must be large enough for class name + method name + method signature
     int _style;
     unsigned char _cache_epoch;
     unsigned char _cache_max_age;


### PR DESCRIPTION
I use using async-profiler, and I print the fully qualified name and the full method signature, on several use cases the method signature has been truncated (because it has many arguments will long fully qualified names)

This PR changes the truncation of the method signature to use the remaining capacity of the buffer instead of 255 const. Also, it increases the frame name buffer size from 800 bytes to 1kb.

