### PR TITLE
Add sanity tests for various idling/blocking operations

### DIFF
--- a/test/one/profiler/test/Output.java
+++ b/test/one/profiler/test/Output.java
@@ -93,7 +93,7 @@ public class Output {
         return new Output(stream(regex).toArray(String[]::new));
     }
 
-    private static long extractSamples(String s) {
+    public static long extractSamples(String s) {
         return Long.parseLong(s.substring(s.lastIndexOf(' ') + 1));
     }
 }

--- a/test/test/wall/PingPongClient.java
+++ b/test/test/wall/PingPongClient.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.wall;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+
+class PingPongClient {
+    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    public static void main(String[] args) throws Exception {
+        long result = 0;
+        for (int i = 0; i < 10; i++) {
+            result += pingPong();
+        }
+    }
+
+    private static long pingPong() {
+        Object monitor = new Object();
+        AtomicLong counter = new AtomicLong();
+        long startTime = System.currentTimeMillis();
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (int i = 0; i < 2; i++) {
+            futures.add(CompletableFuture.supplyAsync(() -> {
+                        while (System.currentTimeMillis() - startTime < 500) {
+                            synchronized (monitor) {
+                                counter.addAndGet(busyWork(Duration.ofMillis(100)));
+                            }
+                            counter.addAndGet(busyWork(Duration.ofMillis(10)));
+                        }
+                        return null;
+                    },
+                    executor));
+        }
+
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
+        return counter.get();
+    }
+
+    private static long busyWork(Duration duration) {
+        long startTime = System.nanoTime();
+        long counter = ThreadLocalRandom.current().nextLong();
+        while (System.nanoTime() - startTime < duration.toNanos()) {
+            counter ^= ThreadLocalRandom.current().nextLong();
+        }
+        return counter;
+    }
+}

--- a/test/test/wall/WaitingClient.java
+++ b/test/test/wall/WaitingClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.wall;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+class WaitingClient {
+    private static final ExecutorService executor = Executors.newCachedThreadPool();
+    public static void main(String[] args) throws Exception {
+        for (int i = 0, id = 1; i < 5000; i++, id += 3) {
+            method1(id);
+        }
+    }
+
+    public static void method1(int id) throws ExecutionException, InterruptedException {
+        method1Impl(id);
+    }
+
+    public static void method1Impl(int id) throws ExecutionException, InterruptedException {
+        sleep(10);
+        Object monitor = new Object();
+        Future<?> wait = executor.submit(() -> method3(id, monitor));
+        method2(id, monitor);
+        synchronized (monitor) {
+            monitor.wait(10);
+        }
+        wait.get();
+    }
+
+    public static void method2(long id, Object monitor) {
+        synchronized (monitor) {
+            method2Impl();
+            monitor.notify();
+        }
+    }
+
+    public static void method2Impl() {
+        sleep(10);
+    }
+
+    public static void method3(long id, Object monitor) {
+        synchronized (monitor) {
+            method3Impl();
+            monitor.notify();
+        }
+    }
+
+    public static void method3Impl() {
+        sleep(10);
+    }
+
+    private static void sleep(long millis) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/test/test/wall/WallTests.java
+++ b/test/test/wall/WallTests.java
@@ -26,4 +26,49 @@ public class WallTests {
         assert s1 > 10 && s2 > 10 && s3 > 10;
         assert Math.abs(s1 - s2) < 5 && Math.abs(s2 - s3) < 5 && Math.abs(s3 - s1) < 5;
     }
+
+    @Test(mainClass = SocketTest.class)
+    public void cpuWallVM(TestProcess p) throws Exception {
+        Output out = p.profile("--cstack vm -e cpu -d 3 -o collapsed");
+        Assert.isGreater(out.ratio("test/wall/SocketTest.main"), 0.25);
+        Assert.isGreater(out.ratio("test/wall/BusyClient.run"), 0.25);
+        Assert.isLess(out.ratio("test/wall/IdleClient.run"), 0.05);
+
+        out = p.profile("--cstack vm -e wall -d 3 -o collapsed");
+        long s1 = out.samples("test/wall/SocketTest.main");
+        long s2 = out.samples("test/wall/BusyClient.run");
+        long s3 = out.samples("test/wall/IdleClient.run");
+        assert s1 > 10 && s2 > 10 && s3 > 10;
+        assert Math.abs(s1 - s2) < 5 && Math.abs(s2 - s3) < 5 && Math.abs(s3 - s1) < 5;
+    }
+
+    @Test(mainClass = WaitingClient.class)
+    public void waitingWallVM(TestProcess p) throws Exception {
+        Output out = p.profile("--cstack vm -e wall --interval 1ms -d 3 -o collapsed");
+
+        long broken = out.stream().filter(s -> s.startsWith("[break_interpreted];")).mapToLong(Output::extractSamples).sum();
+        // there are valid [unknown] root-frames; we may sample the profiler process of parsing libraries and
+        //   we don't have all the symbols and debug info for them available
+        long unknown = countUnknownRoots(out);
+
+        Assert.isLess(broken / (double)out.total(), 0.01);
+        Assert.isEqual(0, unknown);
+    }
+
+    @Test(mainClass = PingPongClient.class)
+    public void pingPongWallVM(TestProcess p) throws Exception {
+        Output out = p.profile("--cstack vm -e wall --interval 1ms -d 3 -o collapsed");
+
+        long broken = out.stream().filter(s -> s.startsWith("[break_interpreted];")).mapToLong(Output::extractSamples).sum();
+        // there are valid [unknown] root-frames; we may sample the profiler process of parsing libraries and
+        //   we don't have all the symbols and debug info for them available
+        long unknown = countUnknownRoots(out);
+
+        Assert.isLess(broken / (double)out.total(), 0.01);
+        Assert.isEqual(0, unknown);
+    }
+
+    private static long countUnknownRoots(Output out) {
+        return out.stream().filter(s -> s.startsWith("[unknown];") && !s.startsWith("[unknown];start_thread;") && !s.startsWith("[unknown];__libc_start_call_main;") && !s.contains("parseLibraries")).mapToLong(Output::extractSamples).sum();
+    }
 }


### PR DESCRIPTION
### Description
This adds two additional tests based on what we have in [Datadog Java Profiler](https://github.com/DataDog/java-profiler/tree/main/ddprof-test/src/test/java/com/datadoghq/profiler/wallclock).

### Motivation and context
These tests will reliably fail on AARCH64 when running on JDK 8/11 from Temurin or Liberica distribution. On other distributions (Corretto and Zulu - other don't seem to provide up-to-date updates of 8 and 11 so, hopefully, their usage will be phased out) the tests are passing just fine.

The main issue seems to be related to somehow mangled FP/LR when calling to some JIT compiled methods (most frequently this fails for things like 'Thread.sleep()` or  `Object.wait()`) where following the standard rules for obtaining FP and LR as SP[-8] and SP[-16] yield bogus values.
The exact location is here - https://github.com/DataDog/async-profiler/blob/f71c31af7b6972fc5432d0be33ed75a34ab3f710/src/stackWalker.cpp#L292

I checked the instructions for the affected methods and the frame size is correct, so the FP and LR values already arrive mangled.

I have a very experimental and WIP code in [branch](https://github.com/DataDog/async-profiler/tree/jb/stackwalker) where I am trying to wrap my head around what and how is actually mangling the linkage. 
A desperate attempt is to use the standard FP walking to recover in such situation - and, to my surprise, it mostly works. Well, if paired with opportunistic recovery from the thread JavaFrameAnchor (if there is any). But still it can create broken or 'surprising' stacktraces 

I want to add these three tests (well, two tests and one extra configuration of the existing test) to allow perhaps someone more knowledgeable in ways how different toolchain/compilation might mangle FP/LR such that they are not directly usable from a compiled method.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
