### PR TITLE
Fix incomplete interpreter stacks produced by VM structs stack walker

### DIFF
--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -74,8 +74,11 @@ class StackFrame {
 
     bool checkInterruptedSyscall();
 
+    void unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
+
     // Check if PC points to a syscall instruction
     static bool isSyscall(instruction_t* pc);
+    static bool isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame);
 };
 
 #endif // _STACKFRAME_H

--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -78,7 +78,6 @@ class StackFrame {
 
     // Check if PC points to a syscall instruction
     static bool isSyscall(instruction_t* pc);
-    static bool isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame);
 };
 
 #endif // _STACKFRAME_H

--- a/src/stackFrame.h
+++ b/src/stackFrame.h
@@ -67,14 +67,13 @@ class StackFrame {
     bool unwindStub(instruction_t* entry, const char* name, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
     bool unwindCompiled(NMethod* nm, uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
     bool unwindAtomicStub(const void*& pc);
+    void unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
 
     void adjustSP(const void* entry, const void* pc, uintptr_t& sp);
 
     bool skipFaultInstruction();
 
     bool checkInterruptedSyscall();
-
-    void unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp);
 
     // Check if PC points to a syscall instruction
     static bool isSyscall(instruction_t* pc);

--- a/src/stackFrame_aarch64.cpp
+++ b/src/stackFrame_aarch64.cpp
@@ -240,7 +240,7 @@ bool StackFrame::checkInterruptedSyscall() {
 #endif
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_aarch64.cpp
+++ b/src/stackFrame_aarch64.cpp
@@ -11,6 +11,7 @@
 #include "stackFrame.h"
 #include "safeAccess.h"
 #include "vmStructs.h"
+#include "vmEntry.h"
 
 
 #ifdef __APPLE__

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -120,7 +120,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
-    sp = frame.senderSP();
+    sp = senderSP();
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -127,9 +127,4 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     // swi #0
     return *pc == 0xef000000;
 }
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // return is_plausible_interpreter_frame to make the code behave the same as before
-    return is_plausible_interpreter_frame;
-}
 #endif // defined(__arm__) || defined(__thumb__)

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -118,7 +118,7 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -118,9 +118,18 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
+void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    pc = stripPointer(*(void**)sp);
+    sp = frame.senderSP();
+}
+
 bool StackFrame::isSyscall(instruction_t* pc) {
     // swi #0
     return *pc == 0xef000000;
 }
 
+bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
+    // return is_plausible_interpreter_frame to make the code behave the same as before
+    return is_plausible_interpreter_frame;
+}
 #endif // defined(__arm__) || defined(__thumb__)

--- a/src/stackFrame_arm.cpp
+++ b/src/stackFrame_arm.cpp
@@ -119,7 +119,7 @@ bool StackFrame::checkInterruptedSyscall() {
 }
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    pc = stripPointer(*(void**)sp);
+    pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = frame.senderSP();
 }
 

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -142,9 +142,4 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     // int 0x80
     return pc[0] == 0xcd && pc[1] == 0x80;
 }
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // return is_plausible_interpreter_frame to make the code behave the same as before
-    return is_plausible_interpreter_frame;
-}
 #endif // __i386__

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -133,9 +133,18 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
+void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    pc = stripPointer(*(void**)sp);
+    sp = frame.senderSP();
+}
+
 bool StackFrame::isSyscall(instruction_t* pc) {
     // int 0x80
     return pc[0] == 0xcd && pc[1] == 0x80;
 }
 
+bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
+    // return is_plausible_interpreter_frame to make the code behave the same as before
+    return is_plausible_interpreter_frame;
+}
 #endif // __i386__

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -133,7 +133,7 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -135,7 +135,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
-    sp = frame.senderSP();
+    sp = senderSP();
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {

--- a/src/stackFrame_i386.cpp
+++ b/src/stackFrame_i386.cpp
@@ -134,7 +134,7 @@ bool StackFrame::checkInterruptedSyscall() {
 }
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    pc = stripPointer(*(void**)sp);
+    pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = frame.senderSP();
 }
 

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -101,7 +101,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
-    sp = frame.senderSP();
+    sp = senderSP();
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -100,7 +100,7 @@ bool StackFrame::checkInterruptedSyscall() {
 }
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    pc = stripPointer(*(void**)sp);
+    pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = frame.senderSP();
 }
 

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -107,9 +107,4 @@ void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& 
 bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x002b0000;
 }
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // return is_plausible_interpreter_frame to make the code behave the same as before
-    return is_plausible_interpreter_frame;
-}
 #endif // __loongarch_lp64

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -99,8 +99,17 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
+void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    pc = stripPointer(*(void**)sp);
+    sp = frame.senderSP();
+}
+
 bool StackFrame::isSyscall(instruction_t* pc) {
     return (*pc) == 0x002b0000;
 }
 
+bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
+    // return is_plausible_interpreter_frame to make the code behave the same as before
+    return is_plausible_interpreter_frame;
+}
 #endif // __loongarch_lp64

--- a/src/stackFrame_loongarch64.cpp
+++ b/src/stackFrame_loongarch64.cpp
@@ -99,7 +99,7 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -153,9 +153,4 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     // sc/svc
     return (*pc & 0x1f) == 17;
 }
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // return is_plausible_interpreter_frame to make the code behave the same as before
-    return is_plausible_interpreter_frame;
-}
 #endif // defined(__PPC64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -145,7 +145,7 @@ bool StackFrame::checkInterruptedSyscall() {
 }
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    pc = stripPointer(*(void**)sp);
+    pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = frame.senderSP();
 }
 

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -146,7 +146,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
-    sp = frame.senderSP();
+    sp = senderSP();
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -144,9 +144,18 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
+void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    pc = stripPointer(*(void**)sp);
+    sp = frame.senderSP();
+}
+
 bool StackFrame::isSyscall(instruction_t* pc) {
     // sc/svc
     return (*pc & 0x1f) == 17;
 }
 
+bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
+    // return is_plausible_interpreter_frame to make the code behave the same as before
+    return is_plausible_interpreter_frame;
+}
 #endif // defined(__PPC64__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)

--- a/src/stackFrame_ppc64.cpp
+++ b/src/stackFrame_ppc64.cpp
@@ -144,7 +144,7 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -101,7 +101,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
-    sp = frame.senderSP();
+    sp = senderSP();
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -100,7 +100,7 @@ bool StackFrame::checkInterruptedSyscall() {
 }
 
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    pc = stripPointer(*(void**)sp);
+    pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = frame.senderSP();
 }
 

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -99,10 +99,19 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
+void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+    pc = stripPointer(*(void**)sp);
+    sp = frame.senderSP();
+}
+
 bool StackFrame::isSyscall(instruction_t* pc) {
     // RISC-V ISA uses ECALL for doing both syscalls and debugger
     // calls, so this might technically mismatch.
     return (*pc) == 0x00000073;
 }
 
+bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
+    // return is_plausible_interpreter_frame to make the code behave the same as before
+    return is_plausible_interpreter_frame;
+}
 #endif // riscv

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -109,9 +109,4 @@ bool StackFrame::isSyscall(instruction_t* pc) {
     // calls, so this might technically mismatch.
     return (*pc) == 0x00000073;
 }
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // return is_plausible_interpreter_frame to make the code behave the same as before
-    return is_plausible_interpreter_frame;
-}
 #endif // riscv

--- a/src/stackFrame_riscv64.cpp
+++ b/src/stackFrame_riscv64.cpp
@@ -99,7 +99,7 @@ bool StackFrame::checkInterruptedSyscall() {
     return retval() == (uintptr_t)-EINTR;
 }
 
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     pc = (uintptr_t)stripPointer(*(void**)sp);
     sp = senderSP();
 }

--- a/src/stackFrame_x64.cpp
+++ b/src/stackFrame_x64.cpp
@@ -18,8 +18,6 @@
 #  define REG(l, m)  _ucontext->uc_mcontext.gregs[REG_##l]
 #endif
 
-const u32 EPILOGUE = 0xec8b4855; // push %rbp, mov %rsp,%rbp
-
 
 uintptr_t& StackFrame::pc() {
     return (uintptr_t&)REG(RIP, rip);
@@ -86,7 +84,7 @@ bool StackFrame::unwindStub(instruction_t* entry, const char* name, uintptr_t& p
         pc = ((uintptr_t*)sp)[0] - 1;
         sp += 8;
         return true;
-    } else if (entry != NULL && *(unsigned int*)entry == EPILOGUE) {
+    } else if (entry != NULL && *(unsigned int*)entry == 0xec8b4855) {
         // The stub begins with
         //   push rbp
         //   mov  rbp, rsp
@@ -225,7 +223,7 @@ bool StackFrame::checkInterruptedSyscall() {
 
 // Though the frame is not complete, but according to the analysis of the instructions, we can use fp to unwind.
 // see https://github.com/async-profiler/async-profiler/pull/1234
-void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
+void StackFrame::unwindIncompleteIntFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
     // If the current instruction (see 0x00007fffe4b4a27b) is to push sender sp onto stack,
     // then using sender_sp_offset we get random value, this may leads to incomplete stacks (shown as rare [unknown]).
     // The following instructions use R13 to save other values, so we can not always use it to read sender sp.

--- a/src/stackFrame_x64.cpp
+++ b/src/stackFrame_x64.cpp
@@ -226,25 +226,30 @@ bool StackFrame::checkInterruptedSyscall() {
 // Though the frame is not complete, but according to the analysis of the instructions, we can use fp to unwind.
 // see https://github.com/async-profiler/async-profiler/pull/1234
 void StackFrame::unwindIncompleteFrame(uintptr_t& pc, uintptr_t& sp, uintptr_t& fp) {
-    if (isSenderSPOnStack((instruction_t*)pc, false)) {
-        sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
-    } else {
-        sp = senderSP();
-    }
-
+    // If the current instruction (see 0x00007fffe4b4a27b) is to push sender sp onto stack,
+    // then using sender_sp_offset we get random value, this may leads to incomplete stacks (shown as rare [unknown]).
+    // The following instructions use R13 to save other values, so we can not always use it to read sender sp.
+    // The corrent way is to read sender sp from r13 at 0x00007fffe4b4a27b, and read sender sp using sender_sp_offset
+    // in the following instructions. This way needs to parse instruction streams, which is dengerous and not maintainable.
+    //
+    // ----------------------------------------------------------------------
+    // method entry point (kind = zerolocals)  [0x00007fffe4b4a220, 0x00007fffe4b4a3c8]  424 bytes
+    // --------------------------------------------------------------------------------
+    // ...
+    //  0x00007fffe4b4a276:   push   %rax
+    //  0x00007fffe4b4a277:   push   %rbp
+    //  0x00007fffe4b4a278:   mov    %rsp,%rbp
+    //  0x00007fffe4b4a27b:   push   %r13            <- push sender sp
+    //  0x00007fffe4b4a27d:   pushq  $0x0
+    //  0x00007fffe4b4a282:   mov    0x8(%rbx),%r13
+    //  0x00007fffe4b4a286:   lea    0x38(%r13),%r13
+    // ...
+    sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
     pc = ((uintptr_t*)fp)[FRAME_PC_SLOT];
     fp = *(uintptr_t*)fp;
 }
 
 bool StackFrame::isSyscall(instruction_t* pc) {
     return pc[0] == 0x0f && pc[1] == 0x05;
-}
-
-bool StackFrame::isSenderSPOnStack(instruction_t* pc, bool is_plausible_interpreter_frame) {
-    // On x64, if is_plausible_interpreter_frame is true, it means sender sp is on the stack.
-    // if is_plausible_interpreter_frame is false and the current instruction is to push sender sp onto stack,
-    // then return false, otherwise return true.
-    // push %rbp; mov %rsp,%rbp; push %r13
-    return is_plausible_interpreter_frame || !(*pc == 0x41 && *(pc + 1) == 0x55 && *(u32*)(pc - 4) == EPILOGUE);
 }
 #endif // __x86_64__

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -18,12 +18,6 @@ const intptr_t MAX_FRAME_SIZE = 0x40000;
 const intptr_t MAX_INTERPRETER_FRAME_SIZE = 0x1000;
 const intptr_t DEAD_ZONE = 0x1000;
 
-#if defined(__x86_64__)
-const bool X64 = true;
-#else
-const bool X64 = false;
-#endif
-
 static inline bool aligned(uintptr_t ptr) {
     return (ptr & (sizeof(uintptr_t) - 1)) == 0;
 }
@@ -338,19 +332,19 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                             sp = frame.senderSP();
                             fp = *(uintptr_t*)fp;
                         } else {
-                            if (X64) {
-                                char* ptr = (char*)pc;
-                                if (*ptr == 0x41 && *(ptr + 1)== 0x55) { // push %r13
-                                    sp = frame.senderSP();
-                                } else {
-                                    sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
-                                }
-                                pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
-                                fp = *(uintptr_t*)fp;
-                            } else {
-                                pc = stripPointer(*(void**)sp);
+#if defined(__x86_64__)
+                            char* ptr = (char*)pc;
+                            if (*ptr == 0x41 && *(ptr + 1)== 0x55) { // push %r13
                                 sp = frame.senderSP();
+                            } else {
+                                sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
                             }
+                            pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
+                            fp = *(uintptr_t*)fp;
+#else
+                            pc = stripPointer(*(void**)sp);
+                            sp = frame.senderSP();
+#endif
                         }
                         continue;
                     }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -18,6 +18,11 @@ const intptr_t MAX_FRAME_SIZE = 0x40000;
 const intptr_t MAX_INTERPRETER_FRAME_SIZE = 0x1000;
 const intptr_t DEAD_ZONE = 0x1000;
 
+#if defined(__x86_64__)
+const bool X64 = true;
+#else
+const bool X64 = false;
+#endif
 
 static inline bool aligned(uintptr_t ptr) {
     return (ptr & (sizeof(uintptr_t) - 1)) == 0;
@@ -333,8 +338,19 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                             sp = frame.senderSP();
                             fp = *(uintptr_t*)fp;
                         } else {
-                            pc = stripPointer(*(void**)sp);
-                            sp = frame.senderSP();
+                            if (X64) {
+                                char* ptr = (char*)pc;
+                                if (*ptr == 0x41 && *(ptr + 1)== 0x55) { // push %r13
+                                    sp = frame.senderSP();
+                                } else {
+                                    sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
+                                }
+                                pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
+                                fp = *(uintptr_t*)fp;
+                            } else {
+                                pc = stripPointer(*(void**)sp);
+                                sp = frame.senderSP();
+                            }
                         }
                         continue;
                     }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -336,7 +336,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                             sp = frame.senderSP();
                             fp = *(uintptr_t*)fp;
                         } else {
-                            frame.unwindIncompleteFrame((uintptr_t&)pc, sp, fp);
+                            frame.unwindIncompleteIntFrame((uintptr_t&)pc, sp, fp);
                         }
                         continue;
                     }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -313,11 +313,12 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth,
                         const char* bcp = ((const char**)fp)[bcp_offset];
                         int bci = bytecode_start == NULL || bcp < bytecode_start ? 0 : bcp - bytecode_start;
                         fillFrame(frames[depth++], FRAME_INTERPRETED, bci, method_id);
-                        if (StackFrame::isSenderSPOnStack((instruction_t*)pc, true)) {
-                            sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
-                        } else {
-                            sp = frame.senderSP();
-                        }
+                        // On aarch64, before sender sp is saved onto stack, using sender_sp_offset we get random value,
+                        // this leads to incomplete stacks (shown as: break_interpreted). Inorder to get correct
+                        // sender sp in this situation, we may need to parse the instruction stream, but this is
+                        // dangerous and not maintainable. The proportion of incomplete stacks is less than 1% on JDK 21,
+                        // on JDK 17 and bellow the incomplete stacks are rare and can be ignored.
+                        sp = ((uintptr_t*)fp)[InterpreterFrame::sender_sp_offset];
                         pc = stripPointer(((void**)fp)[FRAME_PC_SLOT]);
                         fp = *(uintptr_t*)fp;
                         continue;

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -10,6 +10,7 @@ import one.profiler.test.Os;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
+import test.cpu.CpuBurner;
 
 public class CstackTests {
     private static final String PROFILE_COMMAND = "-e cpu -i 10ms -d 1 -o collapsed -a ";
@@ -40,5 +41,11 @@ public class CstackTests {
         assert out.contains("InstanceKlass::initialize");
         assert out.contains("call_stub");
         assert out.contains("JavaMain");
+    }
+
+    @Test(mainClass = CpuBurner.class, os = Os.LINUX, jvmArgs = "-Xint")
+    public void interpreter(TestProcess p) throws Exception {
+        Output out = p.profile("-d 2 -e cpu -i 10ms -o collapsed --cstack vm");
+        assert out.ratio("\\[unknown\\]") < 0.02;
     }
 }

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -44,7 +44,7 @@ public class CstackTests {
     }
 
     @Test(mainClass = CpuBurner.class, os = Os.LINUX, jvmArgs = "-Xint", jvm = Jvm.HOTSPOT)
-    public void interpretedOnlyModeHasLowUnknownRatio(TestProcess p) throws Exception {
+    public void interpreter(TestProcess p) throws Exception {
         Output out = p.profile("-d 2 -e cpu -i 10ms -o collapsed --cstack vm");
         assert out.ratio("\\[unknown\\]") < 0.02;
     }

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -43,7 +43,7 @@ public class CstackTests {
         assert out.contains("JavaMain");
     }
 
-    @Test(mainClass = CpuBurner.class, os = Os.LINUX, jvmArgs = "-Xint")
+    @Test(mainClass = CpuBurner.class, os = Os.LINUX, jvmArgs = "-Xint", jvm = Jvm.HOTSPOT)
     public void interpreter(TestProcess p) throws Exception {
         Output out = p.profile("-d 2 -e cpu -i 10ms -o collapsed --cstack vm");
         assert out.ratio("\\[unknown\\]") < 0.02;

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -44,7 +44,7 @@ public class CstackTests {
     }
 
     @Test(mainClass = CpuBurner.class, os = Os.LINUX, jvmArgs = "-Xint", jvm = Jvm.HOTSPOT)
-    public void interpreter(TestProcess p) throws Exception {
+    public void interpretedOnlyModeHasLowUnknownRatio(TestProcess p) throws Exception {
         Output out = p.profile("-d 2 -e cpu -i 10ms -o collapsed --cstack vm");
         assert out.ratio("\\[unknown\\]") < 0.02;
     }


### PR DESCRIPTION
Hi,

Could I have a review of this patch ? Thanks !

### Description

The instructions of `method entry point` can be viewed as 3 parts.

- The first part is the first instruction to the `epilogue` instruction which pushed `rsp` into `rbp`, i.e. [0x00007fffe4b4a220~ 0x00007fffe4b4a27b). In this part, the `rbp` is not changed, pointing to the caller of the current method.`is_plausible_interpreter_frame` is true, because `rsp` is far enough from `rbp`. Use the code bellow to unwind, we get the caller of the `Method*` in `rbx` as the current method, and we get the caller of the caller of the `Method*` in `rbx` as the sender. The correct way is to use `rbx` to get the current `Method*`, and unwind to the caller of the current method, but it's  a little complex, the place which saved `sender pc` changed multiple times (see the comments in the instructions bellow), so we trade correctness (missing the top frame) for simplicity, I think this is acceptable.

https://github.com/async-profiler/async-profiler/blob/b034e4c3141d0632fd60bc452d7532d84adad572/src/stackWalker.cpp#L310-L322

- The second part is from the end of the first part to the instruction which pushed `bcp` onto stack, i.e. [0x00007fffe4b4a27b~0x00007fffe4b4a2be). In this part, `is_plausible_interpreter_frame` is false, because before `bcp` is push onto stack, `rsp` is not far enough from `rbp`. Though the frame is not complete, fortunately we can use `rbp` to get the `caller sp`, `caller pc` and `caller fp`. The first instruction of this part, i.e. 0x00007fffe4b4a27b, needs to be treated specially, because the `sender sp` is pushed onto stack by it, so at this instruction, the value in `rbp[-1]` is random , we have to use register `r13` to get the `sender sp`.

- The third part is the remaining instructions, i.e. from 0x00007fffe4b4a2be to the end. In this part, `is_plausible_interpreter_frame` is true, and  we can use `rbp` to get the `caller sp`, `caller pc` and `caller fp`. 

There are some differences between the instructions generated with or without `-Xint`. Fortunately, the rules above can be applied to the Compiler (without -Xint) version too.

```
----------------------------------------------------------------------
method entry point (kind = zerolocals)  [0x00007fffe4b4a220, 0x00007fffe4b4a3c8]  424 bytes

--------------------------------------------------------------------------------      
  0x00007fffe4b4a220:   mov    0x8(%rbx),%rdx                               is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=*sp,             sender fp=fp
  0x00007fffe4b4a224:   movzwl 0x2e(%rdx),%ecx          
  0x00007fffe4b4a228:   movzwl 0x2c(%rdx),%edx          
  0x00007fffe4b4a22c:   sub    %ecx,%edx          
          
  0x00007fffe4b4a22e:   cmp    $0x1f5,%edx          
  0x00007fffe4b4a234:   jbe    0x00007fffe4b4a25f          
  0x00007fffe4b4a23a:   mov    %rdx,%rax          
  0x00007fffe4b4a23d:   shl    $0x3,%rax          
  0x00007fffe4b4a241:   add    $0x58,%rax          
  0x00007fffe4b4a245:   add    0x4d0(%r15),%rax                 
  0x00007fffe4b4a24c:   cmp    %rax,%rsp                                              
  0x00007fffe4b4a24f:   ja     0x00007fffe4b4a25f                       
  0x00007fffe4b4a255:   pop    %rax                                                                    
  0x00007fffe4b4a256:   mov    %r13,%rsp                                    is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=rax,             sender fp=fp
  0x00007fffe4b4a259:   push   %rax                                         is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13/*sp,        sender pc=rax,             sender fp=fp   
  0x00007fffe4b4a25a:   jmpq   0x00007fffe4b44f80                           is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=*sp/rax,         sender fp=fp                          
                               
  0x00007fffe4b4a25f:   pop    %rax                                         is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=*sp,             sender fp=fp
  0x00007fffe4b4a260:   lea    -0x8(%rsp,%rcx,8),%r14                       is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=rax,             sender fp=fp
              
  0x00007fffe4b4a265:   test   %edx,%edx                                                               
  0x00007fffe4b4a267:   jle    0x00007fffe4b4a276                           
  0x00007fffe4b4a26d:   pushq  $0x0                           
  0x00007fffe4b4a272:   dec    %edx                           
  0x00007fffe4b4a274:   jg     0x00007fffe4b4a26d                           
                          
generate_fixed_frame               
rbx: Method*                           
r13: sender sp                           
rax: return address                           
                           
  0x00007fffe4b4a276:   push   %rax                  <- return address                    
  0x00007fffe4b4a277:   push   %rbp                  <- old rbp             is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=rax/*sp,         sender fp=fp
  0x00007fffe4b4a278:   mov    %rsp,%rbp             <- new rbp             is_plausible_interpreter_frame=true,  Method*=rbx,           sender sp=r13,            sender pc=sp[1]/rax,       sender fp=fp/*sp
  0x00007fffe4b4a27b:   push   %r13                  <- sender sp           is_plausible_interpreter_frame=false, Method*=rbx,           sender sp=r13,            sender pc=fp[1]/sp[1]/rax, sender fp=*fp/*sp
                  
  0x00007fffe4b4a27d:   pushq  $0x0                                         is_plausible_interpreter_frame=false, Method*=rbx,           sender sp=fp[-1]/r13/*sp, sender pc=fp[1]/rax/sp[2], sender fp=*fp/sp[1]
  0x00007fffe4b4a282:   mov    0x8(%rbx),%r13                  
  0x00007fffe4b4a286:   lea    0x38(%r13),%r13                              is_plausible_interpreter_frame=false, Method*=rbx,           sender sp=fp[-1]/*sp,     sender pc=fp[1]/rax/sp[2], sender fp=*fp/sp[1]
  0x00007fffe4b4a28a:   push   %rbx                  <- push Method*            
  0x00007fffe4b4a28b:   mov    0x8(%rbx),%rdx                               is_plausible_interpreter_frame=false, Method*=fp[-3]/rbx,    sender sp=fp[-1],         sender pc=fp[1]/rax,       sender fp=*fp
  0x00007fffe4b4a28f:   mov    0x8(%rdx),%rdx    
  0x00007fffe4b4a293:   mov    0x18(%rdx),%rdx    
  0x00007fffe4b4a297:   mov    0x70(%rdx),%rdx    
  0x00007fffe4b4a29b:   mov    (%rdx),%rdx    
  0x00007fffe4b4a29e:   push   %rdx    
  0x00007fffe4b4a29f:   pushq  $0x0    
  0x00007fffe4b4a2a4:   mov    0x8(%rbx),%rdx    
  0x00007fffe4b4a2a8:   mov    0x8(%rdx),%rdx    
  0x00007fffe4b4a2ac:   mov    0x10(%rdx),%rdx    
  0x00007fffe4b4a2b0:   push   %rdx    
  0x00007fffe4b4a2b1:   mov    %r14,%rax    
  0x00007fffe4b4a2b4:   sub    %rbp,%rax                                   is_plausible_interpreter_frame=false, Method*=fp[-3]/rbx,    sender sp=fp[-1],         sender pc=fp[1],           sender fp=*fp
  0x00007fffe4b4a2b7:   shr    $0x3,%rax    
  0x00007fffe4b4a2bb:   push   %rax    
  0x00007fffe4b4a2bc:   push   %r13                  <- bcp                

  0x00007fffe4b4a2be:   pushq  $0x0                                        is_plausible_interpreter_frame=true,  Method*=fp[-3]/rbx,    sender sp=fp[-1],         sender pc=fp[1],           sender fp=*fp
  0x00007fffe4b4a2c3:   mov    %rsp,(%rsp)    

  0x00007fffe4b4a2c7:   movb   $0x1,0x479(%r15)
  0x00007fffe4b4a2cf:   cmp    0x4e8(%r15),%rsp
  0x00007fffe4b4a2d6:   ja     0x00007fffe4b4a378
  0x00007fffe4b4a2dc:   mov    %eax,-0x1000(%rsp)
  0x00007fffe4b4a2e3:   mov    %eax,-0x2000(%rsp)
  0x00007fffe4b4a2ea:   mov    %eax,-0x3000(%rsp)
  0x00007fffe4b4a2f1:   mov    %eax,-0x4000(%rsp)
  0x00007fffe4b4a2f8:   mov    %eax,-0x5000(%rsp)
  0x00007fffe4b4a2ff:   mov    %eax,-0x6000(%rsp)
  0x00007fffe4b4a306:   mov    %eax,-0x7000(%rsp)
  0x00007fffe4b4a30d:   mov    %eax,-0x8000(%rsp)
  0x00007fffe4b4a314:   mov    %eax,-0x9000(%rsp)
  0x00007fffe4b4a31b:   mov    %eax,-0xa000(%rsp)
  0x00007fffe4b4a322:   mov    %eax,-0xb000(%rsp)
  0x00007fffe4b4a329:   mov    %eax,-0xc000(%rsp)
  0x00007fffe4b4a330:   mov    %eax,-0xd000(%rsp)
  0x00007fffe4b4a337:   mov    %eax,-0xe000(%rsp)
  0x00007fffe4b4a33e:   mov    %eax,-0xf000(%rsp)
  0x00007fffe4b4a345:   mov    %eax,-0x10000(%rsp)
  0x00007fffe4b4a34c:   mov    %eax,-0x11000(%rsp)
  0x00007fffe4b4a353:   mov    %eax,-0x12000(%rsp)
  0x00007fffe4b4a35a:   mov    %eax,-0x13000(%rsp)
  0x00007fffe4b4a361:   mov    %eax,-0x14000(%rsp)
  0x00007fffe4b4a368:   cmp    0x4e0(%r15),%rsp
  0x00007fffe4b4a36f:   jbe    0x00007fffe4b4a378
  0x00007fffe4b4a371:   mov    %rsp,0x4e8(%r15)
  0x00007fffe4b4a378:   movb   $0x0,0x479(%r15)
  0x00007fffe4b4a380:   cmpb   $0x0,0x1283e68e(%rip)
  0x00007fffe4b4a387:   je     0x00007fffe4b4a3b5
  0x00007fffe4b4a38d:   mov    -0x18(%rbp),%rsi
  0x00007fffe4b4a391:   mov    %r15,%rdi
  0x00007fffe4b4a394:   test   $0xf,%spl
  0x00007fffe4b4a398:   je     0x00007fffe4b4a3b0
  0x00007fffe4b4a39e:   sub    $0x8,%rsp
  0x00007fffe4b4a3a2:   callq  0x00007ffff6ce2480 = SharedRuntime::dtrace_method_entry(JavaThread*, Method*)
  0x00007fffe4b4a3a7:   add    $0x8,%rsp
  0x00007fffe4b4a3ab:   jmpq   0x00007fffe4b4a3b5
  0x00007fffe4b4a3b0:   callq  0x00007ffff6ce2480 = SharedRuntime::dtrace_method_entry(JavaThread*, Method*)
  0x00007fffe4b4a3b5:   movzbl 0x0(%r13),%ebx
  0x00007fffe4b4a3ba:   movabs $0x7ffff73c4a20,%r10
  0x00007fffe4b4a3c4:   jmpq   *(%r10,%rbx,8)
```


### Related issues
#1229 

### Motivation and context
#1225 

### How has this been tested?
Before the fix, incomplete stacks are obvious
![image](https://github.com/user-attachments/assets/f652b4a8-03c1-4c9f-9e60-6aad7139f2bd)
![image](https://github.com/user-attachments/assets/92e48ce0-fe6b-4de6-bb5c-cc206b89ac6a)
![image](https://github.com/user-attachments/assets/c914cba9-1569-4754-b8c2-b8178567a101)
![image](https://github.com/user-attachments/assets/8fd10a79-607a-40ff-bdea-15aa9778287f)

With the fix, incomplete stacks disappeared
![image](https://github.com/user-attachments/assets/656b14a4-5fae-47d6-b397-94f03fa7555d)
![image](https://github.com/user-attachments/assets/b8347ff7-e9c4-427f-b9e7-dec501955569)
![image](https://github.com/user-attachments/assets/e2e33285-ef4b-4a8f-82a5-d6b19d98e6ec)
![image](https://github.com/user-attachments/assets/a1d60e79-96dd-4b93-9cf5-623839bbbe39)

On aarch64, the results are the same as before:
Run without the fix
![image](https://github.com/user-attachments/assets/45a81aee-4311-4d03-af0e-3a3446fe7042)

Run with the fix
![image](https://github.com/user-attachments/assets/7a676978-b6c9-4228-9261-e3e57d99b88a)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
