### PR TITLE
Add logs to assertion failures in StackwalkerTests

### DIFF
--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -23,10 +23,10 @@ public class StackwalkerTests {
         assert p.exitCode() == 0;
         Output output = Output.convertJfrToCollapsed(p.getFilePath("%f"));
         assert output.contains("^Java_test_stackwalker_StackGenerator_largeFrame;" +
-                "doCpuTask");
+                "doCpuTask") : "Captured Stack: " + output;
 
         // There will be no stack frame that contains both main & largeFrame method
-        assert !output.contains(".*main.*largeFrame");
+        assert !output.contains(".*main.*largeFrame") : "Captured Stack: " + output;
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "deepFrame",
@@ -45,10 +45,10 @@ public class StackwalkerTests {
                 "generateDeepStack[^;]*;" +
                 "generateDeepStack[^;]*;" +
                 "generateDeepStack[^;]*;" +
-                "doCpuTask");
+                "doCpuTask") : "Captured Stack: " + output;
 
         // There will be no stack frame that contains both main & deepFrame method
-        assert !output.contains(".*main.*deepFrame");
+        assert !output.contains(".*main.*deepFrame") : "Captured Stack: " + output;
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "leafFrame",
@@ -70,7 +70,7 @@ public class StackwalkerTests {
                 "test/stackwalker/StackGenerator.main_\\[0\\];" +
                 "test/stackwalker/StackGenerator.leafFrame_\\[0\\];" +
                 "Java_test_stackwalker_StackGenerator_leafFrame;" +
-                "doCpuTask");
+                "doCpuTask") : "Captured Stack: " + output;
     }
 
     @Test(mainClass = StackGenerator.class, jvmArgs = "-Xss5m", args = "leafFrame",
@@ -82,6 +82,6 @@ public class StackwalkerTests {
         assert output.contains("^test/stackwalker/StackGenerator.main_\\[0\\];" +
                 "test/stackwalker/StackGenerator.leafFrame_\\[0\\];" +
                 "Java_test_stackwalker_StackGenerator_leafFrame;" +
-                "doCpuTask");
+                "doCpuTask") : "Captured Stack: " + output;
     }
 }


### PR DESCRIPTION
### Description
Adding debug statements for Assertion failure on the StackwalkerTests

### Related issues
N/A

### Motivation and context
Monitor StackwalkerTests as they fail sometimes

### How has this been tested?
make test


Note: This could be something to do for all assertions across async profiler tests

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
