### PR TITLE
#1358: Do not dereference jmethodIDs on JDK 26

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -173,7 +173,7 @@ class Lookup {
     }
 
     bool fillJavaMethodInfo(MethodInfo* mi, jmethodID method, bool first_time) {
-        if (VMMethod::isStaleMethodID(method)) {
+        if (VMMethod::isStaleMethodId(method)) {
             return false;
         }
 

--- a/src/frameName.cpp
+++ b/src/frameName.cpp
@@ -155,7 +155,7 @@ const char* FrameName::typeSuffix(FrameTypeId type) {
 }
 
 void FrameName::javaMethodName(jmethodID method) {
-    if (VMMethod::isStaleMethodID(method)) {
+    if (VMMethod::isStaleMethodId(method)) {
         _str.assign("[stale_jmethodID]");
         return;
     }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -53,10 +53,7 @@ static inline void fillFrame(ASGCT_CallFrame& frame, FrameTypeId type, int bci, 
 
 static jmethodID getMethodId(VMMethod* method) {
     if (!inDeadZone(method) && aligned((uintptr_t)method)) {
-        jmethodID method_id = method->id();
-        if (!inDeadZone(method_id) && aligned((uintptr_t)method_id) && method->validate(method_id)) {
-            return method_id;
-        }
+        return method->validatedId();
     }
     return NULL;
 }

--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -669,6 +669,16 @@ jmethodID VMMethod::id() {
     return NULL;
 }
 
+jmethodID VMMethod::validatedId() {
+    jmethodID method_id = id();
+    if (goodPtr(method_id)) {
+        if (!_can_dereference_jmethod_id || *(VMMethod**)method_id == this) {
+            return method_id;
+        }
+    }
+    return NULL;
+}
+
 NMethod* CodeHeap::findNMethod(char* heap, const void* pc) {
     unsigned char* heap_start = *(unsigned char**)(heap + _code_heap_memory_offset + _vs_low_offset);
     unsigned char* segmap = *(unsigned char**)(heap + _code_heap_segmap_offset + _vs_low_offset);

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -388,12 +388,11 @@ class VMMethod : VMStructs {
   public:
     jmethodID id();
 
-    bool validate(jmethodID id) {
-        return !_can_dereference_jmethod_id || *(VMMethod**)id == this;
-    }
+    // Performs extra validation when VMMethod comes from incomplete frame
+    jmethodID validatedId();
 
     // Workaround for JDK-8313816
-    static bool isStaleMethodID(jmethodID id) {
+    static bool isStaleMethodId(jmethodID id) {
         if (!_can_dereference_jmethod_id) return false;
         VMMethod* vm_method = *(VMMethod**)id;
         return vm_method == NULL || vm_method->id() == NULL;


### PR DESCRIPTION
### Description

Fix crash when dumping profiling results on mainline JDK. The problem was caused by changes in jmethodIDs representation made in [JDK-8268406](https://bugs.openjdk.org/browse/JDK-8268406).

### Related issues

#1358 

### How has this been tested?

Class load-unload stress test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
