### PR TITLE
Publish clang-tidy comments only for non-draft PRs

### DIFF
--- a/.github/workflows/code-check.yml
+++ b/.github/workflows/code-check.yml
@@ -34,6 +34,7 @@ jobs:
             CLANG_TIDY_ARGS_EXTRA="-export-fixes clang-tidy-fixes.yml"
         shell: bash
       - name: Run clang-tidy-pr-comments action
+        if: github.event.pull_request.draft == false
         uses: platisd/clang-tidy-pr-comments@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
In this PR I introduce a check to avoid trying to publish clang-tidy comments if the PR is in draft. If that's the case, reviews cannot be created and the action will fail due to an [HTTP 403](https://github.com/async-profiler/async-profiler/actions/runs/16122344417/job/45491034247#step:7:87).

### Related issues
Discovered in #1366.

### Motivation and context
The action should not fail when comments cannot be published.

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
