### PR TITLE
Automated Maven artifact snapshot publication

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -318,11 +318,9 @@ jobs:
           mvn versions:set -DnewVersion="${VERSION}-SNAPSHOT"
       - name: Create directory structure for Maven release
         run: |
-          mkdir -p native/linux-x64
+          mkdir -p native/{linux-x64,linux-arm64,macos}
           tar xfO async-profiler-*-linux-x64.tar.gz --wildcards "*/lib/*" > native/linux-x64/libasyncProfiler.so
-          mkdir -p native/linux-arm64
           tar xfO async-profiler-*-linux-arm64.tar.gz --wildcards "*/lib/*" > native/linux-arm64/libasyncProfiler.so
-          mkdir -p native/macos
           unzip -p async-profiler-*-macos.zip "*/lib/*" > native/macos/libasyncProfiler.so
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
### Description
In this PR I introduce a new piece of GHA to create a snapshot release in Maven after a push to `master`.

### Related issues
n/a

### Motivation and context
We don't publish SNAPSHOT artifacts yet, but that would be nice for our users.

### How has this been tested?
https://github.com/fandreuz/maven-deploy-test/actions/runs/16350974154/job/46197387100

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
