### PR TITLE
only measure blocked time around the synchronized lock

### DIFF
--- a/test/test/jfr/JfrMultiModeProfiling.java
+++ b/test/test/jfr/JfrMultiModeProfiling.java
@@ -6,12 +6,15 @@
 package test.jfr;
 
 import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -29,7 +32,7 @@ public class JfrMultiModeProfiling {
     private static final List<byte[]> holder = new ArrayList<>();
 
     private static final ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
-    private static final Map<Long, Long> threadLockTimes = new ConcurrentHashMap<>();
+    private static final Map<Long, Boolean> threadIds = new ConcurrentHashMap<>();
 
     static {
         tmx.setThreadContentionMonitoringEnabled(true);
@@ -37,29 +40,29 @@ public class JfrMultiModeProfiling {
 
     public static void main(String[] args) throws InterruptedException {
         ExecutorService executor = Executors.newFixedThreadPool(2);
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+
         for (int i = 0; i < 10; i++) {
-            executor.submit(JfrMultiModeProfiling::cpuIntensiveIncrement);
+            futures.add(CompletableFuture.runAsync(JfrMultiModeProfiling::cpuIntensiveIncrement, executor));
         }
         allocate();
+        futures.forEach(CompletableFuture::join);
+
+        long[] ids = threadIds.keySet().stream().mapToLong(Long::longValue).toArray();
+        Arrays.stream(tmx.getThreadInfo(ids)).mapToLong(ThreadInfo::getBlockedTime).forEach(System.out::println);
+
         executor.shutdown();
         executor.awaitTermination(10, TimeUnit.SECONDS);
-
-        threadLockTimes.values().forEach(System.out::println);
     }
 
     private static void cpuIntensiveIncrement() {
-        long threadId = Thread.currentThread().getId();
-        long totalBlockedTime = threadLockTimes.getOrDefault(threadId, 0L);
+        threadIds.putIfAbsent(Thread.currentThread().getId(), Boolean.TRUE);
 
         for (int i = 0; i < 100_000; i++) {
-            long previousBlockedTime = tmx.getThreadInfo(threadId).getBlockedTime();
             synchronized (lock) {
-                totalBlockedTime += tmx.getThreadInfo(threadId).getBlockedTime() - previousBlockedTime;
                 count += System.getProperties().hashCode();
             }
         }
-
-        threadLockTimes.put(threadId, totalBlockedTime);
     }
 
     private static void allocate() {

--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -91,7 +91,7 @@ public class JfrTests {
 
         Assert.isGreater(eventsCount.get("jdk.ExecutionSample"), 50);
         Assert.isGreater(eventsCount.get("jdk.JavaMonitorEnter"), 10);
-        Assert.isGreater(jfrTotalLockDurationMillis / totalLockDurationMillis, 0.90);
+        Assert.isGreater(jfrTotalLockDurationMillis / totalLockDurationMillis, 0.80);
         Assert.isGreater(eventsCount.get("jdk.ObjectAllocationInNewTLAB"), 50);
     }
 


### PR DESCRIPTION
### Description
Only account for the blocked time around the synchronized lock to avoid increments happening `ObjectMonitor::wait` & `ObjectMonitor::INotify` JDK methods

### Related issues
N/A

### Motivation and context
Fix potential test fragileness 

### How has this been tested?
Test was ran 100 times here https://github.com/Baraa-Hasheesh/async-profiler/actions/runs/17096889460
And here https://github.com/Baraa-Hasheesh/async-profiler/actions/runs/17098823202/job/48489764236 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
