### PR TITLE
Profiler dumps in native threads with loaded JVM

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1278,6 +1278,7 @@ Error Profiler::stop(bool restart) {
 
     _engine->stop();
 
+    SafeJvmContext safe_jvm_context(_dynamic_jvm);
     switchLibraryTrap(false);
     switchThreadEvents(JVMTI_DISABLE);
     updateJavaThreadNames();
@@ -1364,6 +1365,7 @@ Error Profiler::dump(Writer& out, Arguments& args) {
         return Error("Profiler has not started");
     }
 
+    SafeJvmContext safe_jvm_context(_dynamic_jvm);
     if (_state == RUNNING) {
         updateJavaThreadNames();
         updateNativeThreadNames();

--- a/src/profiler.h
+++ b/src/profiler.h
@@ -54,6 +54,7 @@ class Profiler {
     Trap _begin_trap;
     Trap _end_trap;
     bool _nostop;
+    bool _dynamic_jvm;
     Mutex _thread_names_lock;
     // TODO: single map?
     std::map<int, std::string> _thread_names;
@@ -174,7 +175,8 @@ class Profiler {
         _native_libs(),
         _call_stub_begin(NULL),
         _call_stub_end(NULL),
-        _dlopen_entry(NULL) {
+        _dlopen_entry(NULL),
+        _dynamic_jvm(false) {
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             _calltrace_buffer[i] = NULL;
@@ -227,6 +229,14 @@ class Profiler {
     static void crashHandler(int signo, siginfo_t* siginfo, void* ucontext);
     static void wakeupHandler(int signo);
     static void setupSignalHandlers();
+
+    bool dynamicJvm() const {
+        return _dynamic_jvm;
+    }
+
+    void setDynamicJvm(bool dynamic) {
+        _dynamic_jvm = dynamic;
+    }
 
     // CompiledMethodLoad is also needed to enable DebugNonSafepoints info by default
     static void JNICALL CompiledMethodLoad(jvmtiEnv* jvmti, jmethodID method,

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -8,7 +8,7 @@
 
 #include <jvmti.h>
 #include "arch.h"
-
+#include "os.h"
 
 enum FrameTypeId {
     FRAME_INTERPRETED  = 0,
@@ -185,6 +185,15 @@ class VM {
 
     static jvmtiError JNICALL RedefineClassesHook(jvmtiEnv* jvmti, jint class_count, const jvmtiClassDefinition* class_definitions);
     static jvmtiError JNICALL RetransformClassesHook(jvmtiEnv* jvmti, jint class_count, const jclass* classes);
+};
+
+class SafeJvmContext {
+  private:
+    bool _attached;
+
+  public:
+    SafeJvmContext(bool ensure_safe_context);
+    ~SafeJvmContext();
 };
 
 #endif // _VMENTRY_H

--- a/test/one/profiler/test/TestProcess.java
+++ b/test/one/profiler/test/TestProcess.java
@@ -36,7 +36,7 @@ public class TestProcess implements Closeable {
 
     private static final String JAVA_HOME = System.getProperty("java.home");
 
-    private static final Pattern filePattern = Pattern.compile("(%[a-z][a-z0-9_]*)(\\.[a-z]+)?");
+    private static final Pattern filePattern = Pattern.compile("(%[a-zA-Z][a-zA-Z0-9_]*)(\\.[a-z]+)?");
 
     private static final MethodHandle pid = getPidHandle();
 

--- a/test/test/nonjava/NonjavaTests.java
+++ b/test/test/nonjava/NonjavaTests.java
@@ -12,47 +12,57 @@ import one.profiler.test.TestProcess;
 public class NonjavaTests {
 
     // jvm is loaded before the profiling session is started
-    @Test(sh = "%testbin/non_java_app 1 %s.collapsed", output = true)
+    @Test(sh = "%testbin/non_java_app 1 %profile.collapsed", output = true)
     public void jvmFirst(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
 
-        Output out = p.readFile("%s");
+        Output out = p.readFile("%profile");
         assert out.contains("cpuHeavyTask");
     }
 
     // jvm is loaded after the profiling session is started
-    @Test(sh = "%testbin/non_java_app 2 %s.collapsed", output = true)
+    @Test(sh = "%testbin/non_java_app 2 %profile.collapsed", output = true)
     public void profilerFirst(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
 
-        Output out = p.readFile("%s");
+        Output out = p.readFile("%profile");
         assert !out.contains("cpuHeavyTask");
     }
 
     // jvm is loaded between two profiling sessions
-    @Test(sh = "%testbin/non_java_app 3 %f.collapsed %s.collapsed", output = true)
+    @Test(sh = "%testbin/non_java_app 3 %noJvmProfile.collapsed %jvmProfile.collapsed", output = true)
     public void jvmInBetween(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
 
-        Output out = p.readFile("%f");
+        Output out = p.readFile("%noJvmProfile");
         assert out.contains("nativeBurnCpu");
         assert !out.contains("cpuHeavyTask");
 
-        out = p.readFile("%s");
+        out = p.readFile("%jvmProfile");
         assert out.contains("nativeBurnCpu");
         assert out.contains("cpuHeavyTask");
     }
 
     // jvm is loaded before the profiling session is started on a different thread
-    @Test(sh = "%testbin/non_java_app 4 %s.collapsed", output = true)
+    @Test(sh = "%testbin/non_java_app 4 %profile.collapsed", output = true)
     public void differentThread(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;
 
-        Output out = p.readFile("%s");
+        Output out = p.readFile("%profile");
+        assert out.contains("cpuHeavyTask");
+    }
+
+    // Profile is dumped on a different native thread from the one that started the JVM/profiler
+    @Test(sh = "%testbin/non_java_app 5 %profile.collapsed", output = true)
+    public void dumpDifferentThread(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+
+        Output out = p.readFile("%profile");
         assert out.contains("cpuHeavyTask");
     }
 }


### PR DESCRIPTION
### Description
For native apps, it's possible for the user to call the `dump` command using a native thread that is not attached to the JVM
This in turn will cause the stacks/methods to resolved incorrectly 

This change allows the user to correctly dump the profiler data with proper JDK information, even if the JVM isn't attached the the thread in question.

### Related issues
N/A

### Motivation and context
Correctly dump data for native apps when a JVM is present

### How has this been tested?
`make test` 
A new test was added that fails without the changes but passes with them

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
