### PR TITLE
Add `-Wunused-variable` compilation flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ ifeq ($(OS),Darwin)
     MERGE=false
   endif
 else
-  CXXFLAGS += -U_FORTIFY_SOURCE -Wl,-z,defs -Wl,--exclude-libs,ALL -static-libstdc++ -static-libgcc -fdata-sections -ffunction-sections -Wl,--gc-sections -ggdb
+  CXXFLAGS += -U_FORTIFY_SOURCE -Wl,-z,defs -Wl,--exclude-libs,ALL -static-libstdc++ -static-libgcc -fdata-sections -ffunction-sections -Wl,--gc-sections -ggdb -Wunused-variable
   ifeq ($(MERGE),true)
     CXXFLAGS += -fwhole-program
   endif


### PR DESCRIPTION
### Description
Example output:
```
src/instrument.cpp: In member function ‘u16 BytecodeRewriter::rewriteCodeForLatency(const u8*, u16, u8, u16*)’:
src/instrument.cpp:450:21: warning: unused variable ‘offset’ [-Wunused-variable]
  450 |             int16_t offset = (int16_t) ntohs(*(u16*)(code + i + 1));
```

### Related issues
n/a

### Motivation and context
Helps in finding unused variables in code, does not report anything in `master`.

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
