### PR TITLE
GC sections while building asprof too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ else
   ifeq ($(MERGE),true)
     CXXFLAGS += -fwhole-program
   endif
+  CFLAGS += -fdata-sections -ffunction-sections -Wl,--gc-sections
   LIBS += -lrt
   INCLUDES += -I$(JAVA_HOME)/include/linux
   SOEXT=so
@@ -128,7 +129,7 @@ endif
 
 STATIC_BINARY=$(findstring musl-gcc,$(CC))
 ifneq (,$(STATIC_BINARY))
-  CFLAGS += -static -fdata-sections -ffunction-sections -Wl,--gc-sections
+  CFLAGS += -static
 endif
 
 


### PR DESCRIPTION
### Motivation and context

There is no specific reason not to do section gc while building `asprof`. 

One reason against would be increasing the file size because of having more sections and not enough garbage to be collected, which, in this case, not applicable: The file size of `asprof` is reduced by a total of `8 bytes` to `47240`.

### How has this been tested?
Can run `build/bin/asprof`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
