### PR TITLE
Make comp-task matching more generic

### DIFF
--- a/test/test/comptask/ComptaskTests.java
+++ b/test/test/comptask/ComptaskTests.java
@@ -17,7 +17,7 @@ public class ComptaskTests {
     public void testCompTask(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         assert p.exitCode() == 0;
-        assert out.contains(";Compiler::compile_method;(java|sun|jdk)/[^;]+\\.[^;]+;");
-        assert out.contains(";C2Compiler::compile_method;(java|sun|jdk)/[^;]+\\.[^;]+;");
+        assert out.contains(";Compiler::compile_method;(java|sun|jdk)/[^;]+[^;/]\\.[^;/]+;");
+        assert out.contains(";C2Compiler::compile_method;(java|sun|jdk)/[^;]+[^;/]\\.[^;/]+;");
     }
 }


### PR DESCRIPTION
### Description
testCompTask checks that the compfeature is working, by checking for the synthetic frames async-profiler adds
These synthetic frames can be for classes outside of the `java/lang` package 

For example

```
;C2Compiler::compile_method;sun/util/locale/LocaleUtils.caseIgnoreMatch
;C2Compiler::compile_method;jdk/internal/loader/URLClassPath.getLoader
;Compiler::compile_method;sun/net/www/protocol/jar/Handler.parseContextSpec
;Compiler::compile_method;jdk/internal/loader/URLClassPath$JarLoader$1.run
```

This change allows for a more generic matching reducing the possibility of failures 

### Related issues
N/A

### Motivation and context
Reduce possibility for test failure

### How has this been tested?
manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
