### PR TITLE
Converter can skip logging to system out with quiet flag set.

### DIFF
--- a/src/converter/Main.java
+++ b/src/converter/Main.java
@@ -39,14 +39,18 @@ public class Main {
             String input = args.files.get(i);
             String output = isDirectory ? new File(lastFile, replaceExt(input, args.output)).getPath() : lastFile;
 
-            System.out.print("Converting " + getFileName(input) + " -> " + getFileName(output) + " ");
-            System.out.flush();
+            if (!args.quiet) {
+                System.out.print("Converting " + getFileName(input) + " -> " + getFileName(output) + " ");
+                System.out.flush();
+            }
 
             long startTime = System.nanoTime();
             convert(input, output, args);
             long endTime = System.nanoTime();
 
-            System.out.print("# " + (endTime - startTime) / 1000000 / 1000.0 + " s\n");
+            if (!args.quiet) {
+                System.out.print("# " + (endTime - startTime) / 1000000 / 1000.0 + " s\n");
+            }
         }
     }
 

--- a/src/converter/one/convert/Arguments.java
+++ b/src/converter/one/convert/Arguments.java
@@ -40,6 +40,7 @@ public class Arguments {
     public boolean simple;
     public boolean norm;
     public boolean dot;
+    public boolean quiet;
     public long from;
     public long to;
     public final List<String> files = new ArrayList<>();


### PR DESCRIPTION
### Description
Added quiet flag to converter.

### Related issues

### Motivation and context
Using converter inside a larger application. It is polluting the log system with `Converting ... -> ...` messages to system out. It is very annoying to see. 

### How has this been tested?
Ran it with and without quiet flag.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
