### PR TITLE
Don't display kernel warning for non-root users when quiet flag is set.

### DIFF
--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -821,7 +821,7 @@ Error PerfEvents::start(Arguments& args) {
 
     _alluser = args._alluser;
     _kernel_stack = !_alluser && _cstack != CSTACK_NO;
-    if (_kernel_stack && !Symbols::haveKernelSymbols()) {
+    if (!args._quiet && _kernel_stack && !Symbols::haveKernelSymbols()) {
         Log::warn("Kernel symbols are unavailable due to restrictions. Try\n"
                   "  sysctl kernel.perf_event_paranoid=1\n"
                   "  sysctl kernel.kptr_restrict=0");


### PR DESCRIPTION
### Description
Don't print this warning if quiet flag is set:

```
Log::warn("Kernel symbols are unavailable due to restrictions. Try\n"
                  "  sysctl kernel.perf_event_paranoid=1\n"
                  "  sysctl kernel.kptr_restrict=0");
```


### Related issues


### Motivation and context
Using async profiler inside another application. It is distracting to see the warning in the logs with quiet flag set.

### How has this been tested?

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
