### PR TITLE
replace macos-13 with macos-15-intel in GitHub actions

### DIFF
--- a/.github/workflows/test-and-publish-nightly.yml
+++ b/.github/workflows/test-and-publish-nightly.yml
@@ -123,7 +123,7 @@ jobs:
           - runner: macos-15
             test-platform: macos-arm64
             java-version: "21"
-          - runner: macos-13
+          - runner: macos-15-intel
             test-platform: macos-x64
             java-version: "17"
             architecture: x64


### PR DESCRIPTION
### Description
macos-13 label is being retired, replacing it with the newer macos-15-intel 
For more details you can refer [here](https://github.com/actions/runner-images/issues/13045) 

retry is kept as I'm still seeing some performance issues on [x86 based mac instances](https://github.com/Baraa-Hasheesh/async-profiler/actions/runs/18339145833/job/52230233417)

### Related issues
N/A

### Motivation and context
macos-13 is being retired 

### How has this been tested?
Ran with the updated label [here](https://github.com/Baraa-Hasheesh/async-profiler/actions/runs/18339344524)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
