### PR TITLE
Timezone switcher between Local and UTC time in heatmaps

### DIFF
--- a/src/res/heatmap.html
+++ b/src/res/heatmap.html
@@ -3680,8 +3680,7 @@
 			let ms = origin + markIndex * oneMarkMs;
 			let markOffset = markIndex * markPixels - dx;
 
-			let options = currentTimezone === 'UTC' ? timeOptionsTinyWithTZ : timeOptionsTiny;
-			let title = formatTime(ms, options);
+			let title = formatTime(ms, currentTimezone === 'UTC' ? timeOptionsTinyWithTZ : timeOptionsTiny);
 			let x = markOffset + 4;
 			heatC.fillText(title, x, canvasTimeHeight - 1, markPixels);
 
@@ -4227,12 +4226,7 @@
 
 	let moved = false;
 	heatCanvas.onmousemove = function (event) {
-		if (event.offsetY < canvasTimeHeightPx) {
-			heatCanvas.style.cursor = 'pointer';
-		} else {
-			heatCanvas.style.cursor = 'default';
-		}
-
+		heatCanvas.style.cursor = event.offsetY < canvasTimeHeightPx ? 'pointer' : '';
 		let x = Math.floor((event.offsetX + heatCanvasContainer.scrollLeft - canvasScrollPadding) / sqPx);
 		let y = Math.floor(Math.max(0, event.offsetY - canvasTimeHeightPx) / sqPx);
 		if (y >= currentHeatmap.timeSquareRowsCount) {


### PR DESCRIPTION
### Description
Timestamps in heatmaps can be rendered in UTC. The state is stored in a local storage. 

### Related issues
I am not aware of an existing issue. 

### Motivation and context
Before the change, heatmaps would always use the local timezone from a browser. I find it confusing. I prefer UTC when analyzing logs. 

### How has this been tested?
On my local, in Firefox@Linux. 

---


[asprof_utc.webm](https://github.com/user-attachments/assets/23089240-61f1-478f-978b-4f2e4ec2ba31)



By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0

Disclosure: I used an AI assistant to develop this patch. 