### PR TITLE
Skip `Instrument::stop` in `VMDeath` callback

### DIFF
--- a/src/instrument.cpp
+++ b/src/instrument.cpp
@@ -1027,7 +1027,7 @@ Error Instrument::start(Arguments& args) {
 
 void Instrument::stop() {
     _running = false;
-    if (VM::is_jvm_dying()) return;
+    if (VM::isTerminating()) return;
 
     jvmtiEnv* jvmti = VM::jvmti();
     retransformMatchedClasses(jvmti);  // undo transformation

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -32,7 +32,7 @@ int VM::_hotspot_version = 0;
 bool VM::_openj9 = false;
 bool VM::_zing = false;
 
-bool VM::_jvm_dying = false;
+bool VM::_terminating = false;
 
 GetCreatedJavaVMs VM::_getCreatedJavaVMs = NULL;
 
@@ -421,7 +421,7 @@ void JNICALL VM::VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
 }
 
 void JNICALL VM::VMDeath(jvmtiEnv* jvmti, JNIEnv* jni) {
-    VM::set_jvm_dying();
+    _terminating = true;
     Profiler::instance()->shutdown(_global_args);
 }
 

--- a/src/vmEntry.h
+++ b/src/vmEntry.h
@@ -105,7 +105,7 @@ class VM {
     static bool _openj9;
     static bool _zing;
 
-    static bool _jvm_dying;
+    static bool _terminating;
 
     static GetCreatedJavaVMs _getCreatedJavaVMs;
 
@@ -163,12 +163,8 @@ class VM {
     }
 
     // No synchronization, should only be used within the same thread
-    static void set_jvm_dying() {
-        _jvm_dying = true;
-    }
-
-    static bool is_jvm_dying() {
-        return _jvm_dying;
+    static bool isTerminating() {
+        return _terminating;
     }
 
     static bool addSampleObjectsCapability() {


### PR DESCRIPTION
### Description
`Instrument::stop` can be skipped when it is called as part of a `VMDeath` JVMTI callback.

### Related issues
#1534

### Motivation and context
We noticed some test failures in the stress tests related to bytecode rewriting.

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
