### PR TITLE
Missing nativemem setting in JFR file

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -662,6 +662,9 @@ class Recording {
             writeIntSetting(buf, T_EXECUTION_SAMPLE, "wall", args._wall);
             writeBoolSetting(buf, T_EXECUTION_SAMPLE, "nobatch", args._nobatch);
         }
+        if (args._nativemem >= 0) {
+            writeIntSetting(buf, T_MALLOC, "nativemem", args._nativemem);
+        }
 
         writeBoolSetting(buf, T_ALLOC_IN_NEW_TLAB, "enabled", args._alloc >= 0);
         writeBoolSetting(buf, T_ALLOC_OUTSIDE_TLAB, "enabled", args._alloc >= 0);


### PR DESCRIPTION
### Description
While working on different items of the profiler I noticed that this setting was missing from the JFR file

### Related issues
N/A

### Motivation and context
Have nativemem setting clearly reported in the JFR

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
