### PR TITLE
Fix duplicated native stacks with perf_events

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1184,10 +1184,10 @@ Error Profiler::start(Arguments& args, bool reset) {
     if (_cstack == CSTACK_DEFAULT) {
         if (VMStructs::hasStackStructs()) {
             // Use VMStructs by default when possible
-            _cstack = CSTACK_VM;
+            _cstack = args._cstack = CSTACK_VM;
         } else if (VM::isOpenJ9() && DWARF_SUPPORTED) {
             // OpenJ9 libs are compiled with frame pointers omitted
-            _cstack = CSTACK_DWARF;
+            _cstack = args._cstack = CSTACK_DWARF;
         }
     }
 


### PR DESCRIPTION
The bug was introduced in #1539.
When selecting the default stack walking mode, only the cached `_cstack` variable was updated.
We also need to update `_cstack` in the original arguments, so that it is propagated to `CpuEngine` and `FlightRecorder`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
