### PR TITLE
Converter API to parse `jfr` or `collapsed` to a FlameGraph object

### DIFF
--- a/src/converter/Main.java
+++ b/src/converter/Main.java
@@ -68,6 +68,14 @@ public class Main {
         }
     }
 
+    public static FlameGraph parseFlameGraph(String input, Arguments args) throws IOException {
+        if (isJfr(input)) {
+            return JfrToFlame.parse(input, args);
+        } else {
+            return FlameGraph.parse(input, args);
+        }
+    }
+
     private static String getFileName(String fileName) {
         return fileName.substring(fileName.lastIndexOf(File.separatorChar) + 1);
     }

--- a/src/converter/one/convert/FlameGraph.java
+++ b/src/converter/one/convert/FlameGraph.java
@@ -171,6 +171,12 @@ public class FlameGraph implements Comparator<Frame> {
         depth = Math.max(depth, stack.size);
     }
 
+    public void dump(OutputStream out) throws IOException {
+        try (PrintStream ps = new PrintStream(out, false, "UTF-8")) {
+            dump(ps);
+        }
+    }
+
     public void dump(PrintStream out) {
         mintotal = (long) (root.total * args.minwidth / 100);
 
@@ -390,7 +396,7 @@ public class FlameGraph implements Comparator<Frame> {
         return order[f1.getTitleIndex()] - order[f2.getTitleIndex()];
     }
 
-    public static void convert(String input, String output, Arguments args) throws IOException {
+    public static FlameGraph parse(String input, Arguments args) throws IOException {
         FlameGraph fg = new FlameGraph(args);
         try (InputStreamReader in = new InputStreamReader(new FileInputStream(input), StandardCharsets.UTF_8)) {
             if (input.endsWith(".html")) {
@@ -399,6 +405,11 @@ public class FlameGraph implements Comparator<Frame> {
                 fg.parseCollapsed(in);
             }
         }
+        return fg;
+    }
+
+    public static void convert(String input, String output, Arguments args) throws IOException {
+        FlameGraph fg = parse(input, args);
         try (PrintStream out = new PrintStream(output, "UTF-8")) {
             fg.dump(out);
         }

--- a/src/converter/one/convert/JfrToFlame.java
+++ b/src/converter/one/convert/JfrToFlame.java
@@ -10,7 +10,6 @@ import one.jfr.StackTrace;
 import one.jfr.event.AllocationSample;
 import one.jfr.event.Event;
 
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
@@ -73,19 +72,21 @@ public class JfrToFlame extends JfrConverter {
     }
 
     public void dump(OutputStream out) throws IOException {
-        try (PrintStream ps = new PrintStream(out, false, "UTF-8")) {
-            fg.dump(ps);
+        fg.dump(out);
+    }
+
+    public static FlameGraph parse(String input, Arguments args) throws IOException {
+        try (JfrReader jfr = new JfrReader(input)) {
+            JfrToFlame converter = new JfrToFlame(jfr, args);
+            converter.convert();
+            return converter.fg;
         }
     }
 
     public static void convert(String input, String output, Arguments args) throws IOException {
-        JfrToFlame converter;
-        try (JfrReader jfr = new JfrReader(input)) {
-            converter = new JfrToFlame(jfr, args);
-            converter.convert();
-        }
-        try (FileOutputStream out = new FileOutputStream(output)) {
-            converter.dump(out);
+        FlameGraph fg = parse(input, args);
+        try (PrintStream out = new PrintStream(output, "UTF-8")) {
+            fg.dump(out);
         }
     }
 }

--- a/test/one/profiler/test/Output.java
+++ b/test/one/profiler/test/Output.java
@@ -8,7 +8,6 @@ package one.profiler.test;
 import one.convert.Arguments;
 import one.convert.FlameGraph;
 import one.convert.JfrToFlame;
-import one.jfr.JfrReader;
 
 import java.io.*;
 import java.util.Arrays;
@@ -71,24 +70,19 @@ public class Output {
             fg.parseHtml(in);
         }
 
-        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-             PrintStream out = new PrintStream(outputStream)) {
-            fg.dump(out);
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            fg.dump(outputStream);
             return new Output(outputStream.toString("UTF-8").split(System.lineSeparator()));
         }
     }
 
     public static Output convertJfrToCollapsed(String input, String... args) throws IOException {
-        JfrToFlame converter;
-        try (JfrReader jfr = new JfrReader(input)) {
-            Arguments arguments = new Arguments(args);
-            arguments.output = "collapsed";
-            converter = new JfrToFlame(jfr, arguments);
-            converter.convert();
-        }
+        Arguments arguments = new Arguments(args);
+        arguments.output = "collapsed";
+        FlameGraph fg = JfrToFlame.parse(input, arguments);
 
         try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-            converter.dump(outputStream);
+            fg.dump(outputStream);
             return new Output(outputStream.toString("UTF-8").split(System.lineSeparator()));
         }
     }


### PR DESCRIPTION
### Description

Minor refactoring to ease creation of a `FlameGraph` object from any supported input file (jfr, collapsed, html).

### Motivation and context

Prerequisite for Differential FlameGraphs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
