### PR TITLE
Parse FlameGraph title from HTML input

### DIFF
--- a/src/converter/one/convert/Arguments.java
+++ b/src/converter/one/convert/Arguments.java
@@ -11,7 +11,7 @@ import java.util.*;
 import java.util.regex.Pattern;
 
 public class Arguments {
-    public String title = "Flame Graph";
+    public String title;
     public String highlight;
     public String output;
     public String state;

--- a/src/converter/one/convert/FlameGraph.java
+++ b/src/converter/one/convert/FlameGraph.java
@@ -26,6 +26,8 @@ public class FlameGraph implements Comparator<Frame> {
     private final Index<String> cpool = new Index<>(String.class, "");
     private final Frame root = new Frame(0, TYPE_NATIVE);
     private final StringBuilder outbuf = new StringBuilder(FLUSH_THRESHOLD + 1000);
+
+    private String title = "Flame Graph";
     private int[] order;
     private int depth;
     private int lastLevel;
@@ -71,7 +73,11 @@ public class FlameGraph implements Comparator<Frame> {
         boolean needRebuild = args.reverse || args.include != null || args.exclude != null;
 
         try (BufferedReader br = new BufferedReader(in)) {
-            while (!br.readLine().startsWith("const cpool")) ;
+            for (String line; !(line = br.readLine()).startsWith("const cpool"); ) {
+                if (line.startsWith("<h1")) {
+                    title = line.substring(line.indexOf('>') + 1, line.lastIndexOf("</h1>"));
+                }
+            }
             br.readLine();
 
             String s = "";
@@ -192,7 +198,7 @@ public class FlameGraph implements Comparator<Frame> {
         out.print(Math.min(depth * 16, 32767));
 
         tail = printTill(out, tail, "/*title:*/");
-        out.print(args.title);
+        out.print(args.title != null ? args.title : title);
 
         // inverted toggles the layout for reversed stacktraces from icicle to flamegraph
         // and for default stacktraces from flamegraphs to icicle.

--- a/src/converter/one/heatmap/Heatmap.java
+++ b/src/converter/one/heatmap/Heatmap.java
@@ -91,7 +91,7 @@ public class Heatmap {
         stream.print('E');
 
         tail = ResourceProcessor.printTill(stream, tail, "/*title:*/");
-        stream.print(args.title == null ? "Heatmap" : args.title);
+        stream.print(args.title != null ? args.title : "Heatmap");
 
         tail = ResourceProcessor.printTill(stream, tail, "/*startMs:*/0");
         stream.print(startMs);


### PR DESCRIPTION
### Description

Automatically extract FlameGraph title when parsing HTML source.
Without this change, original title is lost during convertion (it is always replaced with the default "Flame Graph", unless configured manually with the `--title` option).

### Motivation and context

Preserve original title when doing `jfrconv` manipulations, e.g., when upgrading an existing flame graph to a new template.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
