### PR TITLE
[GHA] Add more patterns to the EOF newline checker

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           offenders_path: /tmp/eof_newline_offenders.txt
         run: |
-          find . -type f \( -name "*.c" -name "*.h" -o -name "*.cpp" -o -name "*.hpp" -o -name "*.java" -name "*Dockerfile" -name "*.md" -name "*.yml" -name "*.html" -name "*.sh" \) | while read -r file; do
+          find . -path './.git' -prune -o -exec file --mime-type {} + | grep 'text/' | awk -F: '{print $1}' | while read -r file; do
             # Read last byte and verify it's a newline
             if [ -s "$file" ] && [ "$(tail -c1 "$file" | wc -l)" -eq 0 ]; then
               echo "$file" >> "$offenders_path"


### PR DESCRIPTION
### Description
Adding `.h`, `.yml` and `.html` since they were missing in the initial iteration.

### Related issues
#1560 

### Motivation and context
n/a

### How has this been tested?
GHA

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
