### PR TITLE
Allow looping with a duration

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -532,7 +532,6 @@ int main(int argc, const char** argv) {
 
         } else if (arg == "--timeout" || arg == "--loop") {
             params << "," << (arg.str() + 2) << "=" << args.next();
-            if (action == "collect") action = "start";
 
         } else if (arg == "--libpath") {
             libpath = args.next();


### PR DESCRIPTION
### Description
In this PR I let `asprof collect` invocations with `--timeout` or `--loop` work with `--duration`.

### Related issues
n/a

### Motivation and context
The current behavior is to implicitly switch to `start`, which does not support a duration. I think we should either log an error, or take the fix from this PR. The current behavior is confusing (the command will just complete immediately, which is unexpected).

### How has this been tested?
Manual testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
