### PR TITLE
Fix code cache memory leak in lock profiling while looping

### DIFF
--- a/src/lockTracer.cpp
+++ b/src/lockTracer.cpp
@@ -70,6 +70,8 @@ void LockTracer::stop() {
     // Disable Java Monitor events
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTER, NULL);
     jvmti->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_MONITOR_CONTENDED_ENTERED, NULL);
+
+    // We don't reset the Unsafe::park hook due to JDK-8369219
 }
 
 Error LockTracer::initialize(jvmtiEnv* jvmti, JNIEnv* env) {


### PR DESCRIPTION
### Description
We decided to avoid resetting `Unsafe::park` in `LockTracer::stop` to avoid incurring in the problem reported in #1453. We can accept leaving around the hook since the alternative is a memory leak.

### Related issues
This is a workaround for #1453 and [JDK-8369219](https://bugs.openjdk.org/browse/JDK-8369219).

### Motivation and context
The [fix](https://github.com/openjdk/jdk/pull/27742) was merged in OpenJDK, but it will take some time to have it backported.

### How has this been tested?
The reproducer provided by the user is not reproducing the problem after the change:
```
$ ./script/run.sh --agent async-profiler --loop 1s
[monitor] Unsafe.park codelist occurrences: 0 | codecache: no-heap-lines
[monitor] Unsafe.park codelist occurrences: 1 | codecache: no-heap-lines
[monitor] Unsafe.park codelist occurrences: 1 | codecache: no-heap-lines
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
