### PR TITLE
Allow normalStackVMX test to pass on tip JDK

### DIFF
--- a/test/test/stackwalker/StackwalkerTests.java
+++ b/test/test/stackwalker/StackwalkerTests.java
@@ -64,7 +64,7 @@ public class StackwalkerTests {
                 "jni_CallStaticVoidMethod;" +
                 "jni_invoke_static;" +
                 "JavaCalls::call_helper;" +
-                "call_stub;" +
+                FRAME +
                 "test/stackwalker/StackGenerator.main_\\[0\\];" +
                 "test/stackwalker/StackGenerator.leafFrame_\\[0\\];" +
                 "Java_test_stackwalker_StackGenerator_leafFrame;" +


### PR DESCRIPTION
### Description
On newer JDKs (tip) the stub names are different,
This will cause this test to fail as it's expecting `call_stub` but finds `Stub Generator call_stub_stub` 

### Related issues
N/A

### Motivation and context
Allow test to pass when running it with JDK tip

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
