### PR TITLE
Optimize make targets to not compile C/C++ files when not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ CPP_TEST_SOURCES := test/native/testRunner.cpp $(shell find test/native -name '*
 CPP_TEST_HEADER := test/native/testRunner.hpp
 CPP_TEST_INCLUDES := -Isrc -Itest/native
 TEST_LIB_SOURCES := $(wildcard test/native/libs/*)
-TEST_BIN_SOURCES := $(shell find test/test \( -name "*.c" -o -name "*.cpp" \))
+TEST_BIN_SOURCES := $(shell find test/test -name "*.c*")
 
 ifeq ($(JAVA_HOME),)
   JAVA_HOME:=$(shell java -cp . JavaHome)


### PR DESCRIPTION
### Description
Currently make file does some unnecessary work as mentioned in ticket #1562
* Compiling unit tests for cases where user is testing integration `make test TESTS=cpu`
* Running unit tests for cases where user  is testing integration `make test TESTS=cpu`
* Compiling integration test binaries for unit tests 

After changes, 
unit tests won't compile for integration target  `make test TESTS=cpu`
unit tests won't run for integration target `make test TESTS=cpu`
integration binaries won't compile for unit test target `make test-cpp`


Note:
* I did consider splitting `build-test-libs` into 2 different targets for unit tests & integration tests (each has a unique group of libs) but opted against it for simplicity 
* I used if checks as they are the most straight forward approach in this case to check both  `MAKECMDGOALS` & `TESTS` to validate if unit tests are needed or not

### Related issues
#1562

### Motivation and context
Optimize make flow for faster feedback loop

### How has this been tested?
manual testing 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
