### PR TITLE
Enable ComptaskTests  test for JDK25+

### DIFF
--- a/test/test/comptask/ComptaskTests.java
+++ b/test/test/comptask/ComptaskTests.java
@@ -12,9 +12,7 @@ public class ComptaskTests {
         mainClass = Main.class,
         agentArgs = "start,features=comptask,collapsed,interval=1ms,file=%f",
         jvmArgs = "-Xcomp",
-        jvm = Jvm.HOTSPOT,
-        // TODO: remove version filter after the fix for JDK-8367689 is released
-        jvmVer = {8, 24}
+        jvm = Jvm.HOTSPOT
     )
     public void testCompTask(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");


### PR DESCRIPTION
### Description
Previously this test was disabled on JDK 25 until the needed fix was back-ported,

The required fix is now available on the latest version of Corretto25, so the filter is no longer needed

### Related issues
N/A

### Motivation and context
Enable tests for modern JDKs to better find future regressions 

### How has this been tested?
`make` & `make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
