### PR TITLE
Do not block any signals during execution of a custom crash handler

### DIFF
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -279,8 +279,9 @@ SigAction OS::replaceCrashHandler(SigAction action) {
     struct sigaction sa;
     sigaction(SIGSEGV, NULL, &sa);
     SigAction old_action = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
+    sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = action;
-    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART | SA_NODEFER;
     sigaction(SIGSEGV, &sa, NULL);
     return old_action;
 }

--- a/src/os_macos.cpp
+++ b/src/os_macos.cpp
@@ -247,14 +247,16 @@ SigAction OS::replaceCrashHandler(SigAction action) {
 
     sigaction(SIGBUS, NULL, &sa);
     orig_sigbus_handler = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
+    sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = action;
-    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART | SA_NODEFER;
     sigaction(SIGBUS, &sa, NULL);
 
     sigaction(SIGSEGV, NULL, &sa);
     orig_sigsegv_handler = sa.sa_handler == SIG_DFL ? restoreSignalHandler : sa.sa_sigaction;
+    sigemptyset(&sa.sa_mask);
     sa.sa_sigaction = action;
-    sa.sa_flags |= SA_SIGINFO | SA_RESTART;
+    sa.sa_flags |= SA_SIGINFO | SA_RESTART| SA_NODEFER;
     sigaction(SIGSEGV, &sa, NULL);
 
     // Return an action that dispatches to one of the original handlers depending on signo,


### PR DESCRIPTION
### Description

Fix a bug that permanently blocks certain signals after StackWalker crash protection triggers.

### Related issues

#1587

### Motivation and context

If SIGSEGV happens during VMStructs-based stack walking (rare but acceptable case), async-profiler's crash protection takes over and executes `StackWalker::checkFault()`. While signal handler is running, many signals are blocked, including SIGSEGV. Then `StackWalker::checkFault()` calls `longjmp` and execution continues in `StackWalker::walkVM` without resetting blocked signals.

This is not a problem for CPU profiling, since `StackWalker::walkVM` itself is called from SIGPROF handler and thread's sigmask is restored upon return from this handler. But when stack walking is called from the allocation profiler (`cstack=vmx`), sigmask remains corrupted after execution of the crash handler, and subsequent SIGSEGV instantly terminates the process.

The fix includes two changes:
1. Empty `sa_mask` when installing the crash handler so no additional signals are blocked.
2. Add `SA_NODEFER` flag to prevent from adding SIGSEGV/SIGBUS to the thread's signal mask.

### How has this been tested?

Injected random segfaults in `StackWalker::walkVM` and ran several Java apps with
```
-agentlib:asyncProfiler=start,event=cpu,alloc,cstack=vmx,file=out.jfr
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
