### PR TITLE
Support running tests on a different JDK from the compile JDK

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ JAR=$(JAVA_HOME)/bin/jar
 JAVA=$(JAVA_HOME)/bin/java
 JAVA_TARGET=8
 JAVAC_OPTIONS=--release $(JAVA_TARGET) -Xlint:-options
+TEST_JAVA ?= $(JAVA_HOME)/bin/java
 
 TEST_LIB_DIR=build/test/lib
 TEST_BIN_DIR=build/test/bin
@@ -263,7 +264,7 @@ test-cpp: build-test-cpp
 
 test-java: build-test-java
 	echo "Running tests against $(LIB_PROFILER)"
-	$(JAVA) $(TEST_FLAGS) -ea -cp "build/$(TEST_JAR):build/jar/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*" one.profiler.test.Runner $(subst $(COMMA), ,$(TESTS))
+	$(TEST_JAVA) $(TEST_FLAGS) -ea -cp "build/$(TEST_JAR):build/jar/*:$(TEST_DEPS_DIR)/*:$(TEST_GEN_DIR)/*" one.profiler.test.Runner $(subst $(COMMA), ,$(TESTS))
 
 coverage: override FAT_BINARY=false
 coverage: clean-coverage


### PR DESCRIPTION
### Description
While async-profiler supports running on JDK8, it doesn't support compiling using that JDK, & a minimum JDK11 is required to build the profiler

This makes it harder to test ongoing changes against JDK8 directly as user will need to:
* Run `make build-test` with JDK11+ 
* Run `make test` with JDK8

In practice this usually ends up with me running 3 commands:
* Run `make test` -> Find I have JDK8 on terminal & build fails
* Run `JAVA_HOME=JDK11_HOME  make build-test`
* Run `make test`

In this PR I propose adding a make variable, that would allow you to automatically compile profiler on 1 JDK & run on a different JDK
* `make test TEST_JAVA=$JDK8_HOME/bin/java`
* `JAVA_HOME=JDK17_HOME make test TEST_JAVA=$JDK8_HOME/bin/java`

Note: I did consider making the variable be the test java home, but opted against it as the current implementation allows the user to pass a custom executable to invoke the tests which can be a bash script (Eventually will call java)

### Related issues
N/A

### Motivation and context
Make User experience smoother when the need arise to compile on JDK different from the JDK to test

### How has this been tested?
manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
