### PR TITLE
Limit reported stacks properly according to stackdepth argument (#1608)

### DIFF
--- a/src/profiler.h
+++ b/src/profiler.h
@@ -117,6 +117,10 @@ class Profiler {
     int getJavaTraceAsync(void* ucontext, ASGCT_CallFrame* frames, int max_depth, StackContext* java_ctx);
     int getJavaTraceJvmti(jvmtiFrameInfo* jvmti_frames, ASGCT_CallFrame* frames, int start_depth, int max_depth);
     void fillFrameTypes(ASGCT_CallFrame* frames, int num_frames, NMethod* nmethod);
+
+    int getJavaTrace(void *ucontext, ASGCT_CallFrame *frames, jvmtiFrameInfo *jvmti_frames, EventType event_type,
+                      int num_frames, StackContext java_ctx);
+
     void setThreadInfo(int tid, const char* name, jlong java_thread_id);
     void updateThreadName(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread);
     void updateJavaThreadNames();


### PR DESCRIPTION
### Description

Currently, the jstackdepth argument only limits the Java part of the reported stacktraces. This can be confusing, because if a stacktrace contains native frames, then stacktraces can become much larger than what has been requested by jstackdepth. Restricting the number of reported stack-frames - Java and native combined - to jstackdepth is less confusing/more usable and also brings an opportunity to save memory both in the JFR recording and in-memory while constructing the stacktraces.

### Motivation and context

It is confusing for the user when he specifies a maximum stack-depth, but then the reported stack-traces contain more frames than specified. The fact that the argument only applies to Java stack frames is not obvious and overall rather useless to the end user, especially in mixed stack traces. Even worse, the exact behaviour seems to depend on the stack-walker being used. It would improve the usefulness and usability of the stackdepth argument if it applies for the total number of frames (Java and native combined) and regardless of the stack-walker that is in use.

### How has this been tested?

I have ran the akka workload of the Renaissance benchmark with CPU profiling and the jstackdepth argument set to 8, and observed that many samples report more than 8 frames. With the fix, it consistently reports a maximum of 8 frames. It seems very difficult to make an automated test for this.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
