### PR TITLE
Fix asprof incorrectly existing with non zero exit code

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -588,25 +588,20 @@ int main(int argc, const char** argv) {
         signal(SIGTERM, sigint_handler);
 
         while (time_micros() < end_time) {
+            sleep(1);
+
             if (kill(pid, 0) != 0) {
                 fprintf(stderr, "Process exited\n");
                 if (use_tmp_file) print_file(file, STDOUT_FILENO);
                 return 0;
             }
-            sleep(1);
         }
 
         fprintf(stderr, end_time != 0 ? "Done\n" : "Interrupted\n");
         signal(SIGINT, SIG_DFL);
         // Do not reset SIGTERM handler to allow graceful shutdown
 
-        // It's possible for java process to die during the last `sleep` call in the waiting loop
-        // Running jattach in that case will cause the asprof to incorrectly conclude with non 0 exit code
-        if (kill(pid, 0) == 0) {
-            run_jattach(pid, String("stop,file=") << file << "," << output << format << ",log=" << logfile);
-        } else if (use_tmp_file) {
-            print_file(file, STDOUT_FILENO);
-        }
+        run_jattach(pid, String("stop,file=") << file << "," << output << format << ",log=" << logfile);
     } else {
         if (action == "start" || action == "resume") run_fdtransfer(pid, fdtransfer);
         run_jattach(pid, String(action) << ",file=" << file << "," << output << format << params << ",log=" << logfile);


### PR DESCRIPTION
### Description
In `collect` mode, the `asprof` will do the following:
* run `jattach` to start the profiler
* sleep/wait until the full profiling duration
* run `jattach` to stop the profiler 

During some testing, I noticed that it's possible for the Java process to exit during the call of the last `sleep` call that the `asprof` does to wait for session time to be exhausted 

If that happens the follow up `jattach` call will fail, as the process is already dead,

This change doesn't not fully solve the issue as the race condition still exists but will make much less likely to happen as it checks the process is still alive before calling `jattach` to stop the profiler

### Related issues
N/A

### Motivation and context
Fix exist code for the `asprof` in case Java process exiting before `stop` is called

### How has this been tested?
manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
