### PR TITLE
Sync jattach sources - avoid busy waiting for dead process

### DIFF
--- a/src/jattach/jattach_hotspot.c
+++ b/src/jattach/jattach_hotspot.c
@@ -63,7 +63,7 @@ static int start_attach_mechanism(int pid, int nspid) {
     do {
         nanosleep(&ts, NULL);
         result = check_socket(nspid);
-    } while (result != 0 && (ts.tv_nsec += 20000000) < 500000000);
+    } while (result != 0 && (ts.tv_nsec += 20000000) < 500000000 && kill(pid, 0) == 0);
 
     unlink(path);
     return result;


### PR DESCRIPTION
### Description
Synchronize async-profiler with `jattach` source.

This includes a fix that prevents the `jattach` from waiting on an already dead process 

### Related issues
N/A

### Motivation and context
Do not let jattach wait for an already dead process

### How has this been tested?
Manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
