### PR TITLE
Fix issue where the jfrconv uses native lock samples for leak detection

### DIFF
--- a/src/converter/Main.java
+++ b/src/converter/Main.java
@@ -35,10 +35,6 @@ public class Main {
             }
         }
 
-        if (args.leak) {
-            args.nativemem = true;
-        }
-
         for (int i = 0; i < fileCount; i++) {
             String input = args.files.get(i);
             String output = isDirectory ? new File(lastFile, replaceExt(input, args.output)).getPath() : lastFile;

--- a/src/converter/one/convert/JfrConverter.java
+++ b/src/converter/one/convert/JfrConverter.java
@@ -29,7 +29,7 @@ public abstract class JfrConverter extends Classifier {
         this.args = args;
 
         EventCollector collector = createCollector(args);
-        this.collector = args.leak ? new MallocLeakAggregator(collector, args.tail) : collector;
+        this.collector = args.nativemem && args.leak ? new MallocLeakAggregator(collector, args.tail) : collector;
     }
 
     public void convert() throws IOException {


### PR DESCRIPTION
### Description
`jfrconv` might be used to find memory leaks by using `--leak --nativemem`

However currently if the user selects `--leak --nativemem --nativelock` the `jfrconv` will end up using the leak aggregator on NativeLock events which is wrong 

This change gives priority for `nativemem` when selected to fix that, also for better UX `--leak` will now auto enable `nativemem`, so the user can just do `jfrconv file.jfr --leak` 

### Related issues
N/A

### Motivation and context
Fix cast exceptions when use user selects both `--leak` & `--nativelock` at same time 

### How has this been tested?
manual testing 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
