### PR TITLE
Record JFR event to report buffer lock acquisition failures

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -258,6 +258,8 @@ class Recording {
     RecordingBuffer _proc_buf;
     ProcessSampler _process_sampler;
 
+    u64 _last_ticks_skipped;
+
     static float ratio(float value) {
         return value < 0 ? 0 : value > 1 ? 1 : value;
     }
@@ -272,6 +274,7 @@ class Recording {
         _bytes_written = 0;
         _memfd = -1;
         _in_memory = false;
+        _last_ticks_skipped = Profiler::instance()->_failures[-ticks_skipped];
 
         _chunk_size = args._chunk_size <= 0 ? MAX_JLONG : (args._chunk_size < 262144 ? 262144 : args._chunk_size);
         _chunk_time = args._chunk_time <= 0 ? MAX_JLONG : (args._chunk_time < 5 ? 5 : args._chunk_time) * 1000000ULL;
@@ -330,11 +333,16 @@ class Recording {
         close(_fd);
     }
 
+    void writePerChunkEvents() {
+        writeProfilerFailures(_buf);
+        writeNativeLibraries(_buf);
+    }
+
     off_t finishChunk() {
         flush(&_monitor_buf);
         flush(&_proc_buf);
 
-        writeNativeLibraries(_buf);
+        writePerChunkEvents();
 
         for (int i = 0; i < CONCURRENCY_LEVEL; i++) {
             flush(&_buf[i]);
@@ -803,6 +811,19 @@ class Recording {
         }
 
         jvmti->Deallocate((unsigned char*)keys);
+    }
+
+    void writeProfilerFailures(Buffer* buf) {
+        u64 new_ticks_skipped = Profiler::instance()->_failures[-ticks_skipped];
+        if (new_ticks_skipped == _last_ticks_skipped) return;
+
+        int start = buf->skip(1);
+        buf->put8(T_PROFILER_FAILURES);
+        buf->putVar64(TSC::ticks());
+        buf->putVar64(new_ticks_skipped - _last_ticks_skipped);
+        buf->put8(start, buf->offset() - start);
+
+        _last_ticks_skipped = new_ticks_skipped;
     }
 
     void writeNativeLibraries(Buffer* buf) {

--- a/src/jfrMetadata.cpp
+++ b/src/jfrMetadata.cpp
@@ -296,6 +296,11 @@ JfrMetadata::JfrMetadata() : Element("root") {
                 << field("ioRead", T_LONG, "I/O Read Bytes", F_BYTES)
                 << field("ioWrite", T_LONG, "I/O Write Bytes", F_BYTES))
 
+            << (type("profiler.Failures", T_PROFILER_FAILURES, "Profiler failures")
+                << category("Profiler")
+                << field("startTime", T_LONG, "Start Time", F_TIME_TICKS)
+                << field("ticksSkipped", T_LONG, "Profiler ticks skipped"))
+
             << (type("jdk.jfr.Label", T_LABEL, NULL)
                 << field("value", T_STRING))
 

--- a/src/jfrMetadata.h
+++ b/src/jfrMetadata.h
@@ -68,6 +68,7 @@ enum JfrType {
     T_USER_EVENT = 122,
     T_PROCESS_SAMPLE = 123,
     T_NATIVE_LOCK = 124,
+    T_PROFILER_FAILURES = 125,
 
     // types after T_ANNOTATION inherit from java.lang.annotation.Annotation, see JfrMetadata::type
     T_ANNOTATION = 200,


### PR DESCRIPTION
### Description
In this PR I introduce a custom JFR event to report currently unreported profiler failures, as discussed in the linked issues:
```
profiler.Failures {
  startTime = 10:45:28.729
  ticksSkipped = 2
}
```
The event is reported once per chunk, at the end of the chunk.

### Related issues
#1111, #1112 

### Motivation and context
The counter is already included in our profiler metrics (#1568), and having it as a JFR event doesn't cost much and could provide insights to our users about the profiler health.

### How has this been tested?
Manual testing. Hard to write a deterministic test since we don't have a knob to reduce `CONCURRENCY_LEVEL`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
