### PR TITLE
None JVM thread can not have Java frames

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -82,7 +82,8 @@ int StackWalker::walkFP(void* ucontext, const void** callchain, int max_depth, S
 
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < max_depth) {
-        if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc))) {
+        if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc)) &&
+            VMThread::current() != nullptr) {  // If it is not a JVM thread, it cannot have Java frame
             java_ctx->set(pc, sp, fp);
             break;
         }
@@ -133,7 +134,8 @@ int StackWalker::walkDwarf(void* ucontext, const void** callchain, int max_depth
 
     // Walk until the bottom of the stack or until the first Java frame
     while (depth < max_depth) {
-        if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc))) {
+        if (CodeHeap::contains(pc) && !(depth == 0 && frame.unwindAtomicStub(pc)) &&
+            VMThread::current() != nullptr) {  // If it is not a JVM thread, it cannot have Java frame
             // Don't dereference pc as it may point to unreadable memory
             // frame.adjustSP(page_start, pc, sp);
             java_ctx->set(pc, sp, fp);


### PR DESCRIPTION
### Description
A none JVM thread can not have Java frames.
Without this patch, J9 stack walk is unreliable.

### Related issues

### Motivation and context
With the fix, we can enable native thread instrument with J9.

### How has this been tested?
Ran unit tests, `NativeThreadTest` and `DynamicNativeThread` tests failed without this patch, passed with it,

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
