### PR TITLE
Unwind vDSO correctly on Linux-ARM64

### DIFF
--- a/test/test/recovery/RecoveryTests.java
+++ b/test/test/recovery/RecoveryTests.java
@@ -73,4 +73,13 @@ public class RecoveryTests {
         Assert.isLess(out.ratio("^\\[unknown"), 0.01, "No more than 1% of unknown frames");
         Assert.isLess(out.ratio("^[^ ;]+(;[^ ;]+)? "), 0.01, "No more than 1% of short stacks");
     }
+
+    // Verify that System.currentTimeMillis() intrinsic is unwound correctly
+    @Test(mainClass = TimeLoop.class, jvm = Jvm.HOTSPOT, jvmVer = {11, Integer.MAX_VALUE}, debugNonSafepoints = true)
+    public void currentTimeMillis(TestProcess p) throws Exception {
+        Output out = p.profile("-d 3 -e cpu -o collapsed");
+        Assert.isLess(out.ratio("^\\[unknown"), 0.01, "No more than 1% of unknown frames");
+        Assert.isLess(out.ratio("^\\[break_"), 0.01, "No more than 1% of broken stacks");
+        Assert.isLess(out.ratio("^\\[vdso]"), 0.01, "vDSO should have symbol information");
+    }
 }

--- a/test/test/recovery/TimeLoop.java
+++ b/test/test/recovery/TimeLoop.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.recovery;
+
+public class TimeLoop {
+
+    public static void main(String[] args) throws InterruptedException {
+        long busyTime = 100;
+        long idleTime = 100;
+
+        while (true) {
+            long startTime = System.currentTimeMillis();
+            while (System.currentTimeMillis() - startTime < busyTime) {
+                // Burn CPU
+            }
+            Thread.sleep(idleTime);
+        }
+    }
+}


### PR DESCRIPTION
### Description

This PR fixes two issues related to [vDSO](https://man7.org/linux/man-pages/man7/vdso.7.html):

1. vDSO symbols (e.g. `__kernel_gettimeofday`) are not resolved if vDSO object has no `DT_RELAENT` program header. In this case, `parseDynamicSection` returns early despite that `loadSymbolTable` does not need the value of `DT_RELAENT`.
2. If `vDSO` does not have DWARF unwinding info (`PT_GNU_EH_FRAME` program header), assume an empty frame layout instead of the default layout. There was a partial fix for this problem in #819, but that fix was incomplete: it did not handle the case when `PT_GNU_EH_FRAME` was absent.

### Related issues

#819, #1636

### Motivation and context

When testing an example program from #1636 on linux-arm64, I found that stack walking of `System.currentTimeMillis` was broken because of the two issues mentioned in the description.

**Before the fix:**

<img width="1890" height="264" alt="before" src="https://github.com/user-attachments/assets/a93a2064-8f74-4131-90b8-7b0faeae41bd" />

**After the fix:**

<img width="1890" height="264" alt="after" src="https://github.com/user-attachments/assets/57813a44-4991-493b-b180-e841cbf371a4" />


### How has this been tested?

Ubuntu 20.04 AArch64
Amazon Corretto 11
```
java -agentpath:build/lib/libasyncProfiler.so=start,event=cpu,file=out.html Cpu1
```

\+ Added new test.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
