### PR TITLE
Add missing stub for `com.google.protobuf.ProtocolStringList`

### DIFF
--- a/test/stubs/com/google/protobuf/ProtocolStringList.java
+++ b/test/stubs/com/google/protobuf/ProtocolStringList.java
@@ -1,0 +1,8 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.google.protobuf;
+
+public interface ProtocolStringList extends java.util.List<String> {}


### PR DESCRIPTION
### Description
Fixes the error reported [here](https://github.com/async-profiler/async-profiler/pull/1624#issuecomment-3723405076).

### Related issues
Caused by a missing stub after I updated the compiled Protobuf definitions in #1624.

### Motivation and context
n/a

### How has this been tested?
Local testing.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
