### PR TITLE
Disallow incorrect usage of jfrsync

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1095,6 +1095,10 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("Profiling event is not supported with non-Java processes");
     }
 
+    if (args._jfr_sync && !VM::loaded()) {
+        return Error("jfrsync is not supported with non-Java processes");
+    }
+
     if (args._fdtransfer) {
         if (!FdTransferClient::connectToServer(args._fdtransfer_path)) {
             return Error("Failed to initialize FdTransferClient");
@@ -1198,14 +1202,6 @@ Error Profiler::start(Arguments& args, bool reset) {
 
     if (_cstack != CSTACK_VM && _features.mixed) {
         return Error("mixed feature is only allowed with VMStructs stack walking");
-    }
-
-    if (args._jfr_sync && args._output != OUTPUT_JFR) {
-        return Error("jfrsync is only supported with jfr output");
-    }
-
-    if (args._jfr_sync && !VM::loaded()) {
-        return Error("jfrsync is not supported with non-Java processes");
     }
 
     // Kernel symbols are useful only for perf_events without --all-user


### PR DESCRIPTION
### Description
`jfrsync` is only allowed with jfr output format & only on a process that has a JVM instance

Currently it's possible for the user to pass `jfrsync` on a native process which will cause the application to crash 

Following checks will fail early & report back to user with clear warning messages 

### Related issues
N/A

### Motivation and context
prevent bad user input on async-profiler from crashing the application 

### How has this been tested?
manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
