### PR TITLE
Fix stop sequence in `Profiler::start`

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1257,13 +1257,13 @@ Error Profiler::start(Arguments& args, bool reset) {
     return Error::OK;
 
 error7:
-    if (_event_mask & EM_METHOD_TRACE) instrument.stop();
-
-error6:
     if (_event_mask & EM_NATIVELOCK) native_lock_tracer.stop();
 
-error5:
+error6:
     if (_event_mask & EM_NATIVEMEM) malloc_tracer.stop();
+
+error5:
+    if (_event_mask & EM_WALL) wall_clock.stop();
 
 error4:
     if (_event_mask & EM_LOCK) lock_tracer.stop();


### PR DESCRIPTION
### Description
I spotted a small mistake in the stop sequence in `Profiler::start`. As a result, when an error occurs during any of `MallocTracer::start`, `NativeLockTracer::start`, and `Instrument::start`, `WallClock::stop` won't be called.

### Related issues
n/a

### Motivation and context
`error5` is stopping `malloc_tracer`, but it should stop `wall_clock`.

### How has this been tested?
n/a

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
