### PR TITLE
Event=cpu not switching alluser flag when kernel symbols are not available

### DIFF
--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -796,8 +796,8 @@ Error PerfEvents::start(Arguments& args) {
                   "  sysctl kernel.perf_event_paranoid=1\n"
                   "  sysctl kernel.kptr_restrict=0");
         _kernel_stack = false;
-        // Automatically switch on alluser for non-CPU events, if kernel profiling is unavailable
-        _alluser = strcmp(args._event, EVENT_CPU) != 0 && !supported();
+        // Automatically switch on alluser if kernel profiling is unavailable
+        _alluser = !supported();
     }
     _use_perf_mmap = _kernel_stack || _cstack == CSTACK_DEFAULT || _cstack == CSTACK_LBR || _record_cpu;
 


### PR DESCRIPTION
### Description
Missed when doing #1654, I noticed that `strcmp(args._event, EVENT_CPU)` basically prevented the `event=cpu` from switching the `alluser` flag 

This check no longer makes sense as one of the following is correct:
* event=cpu & `PerfEvents::supported` is true 
* event=cpu-clock
* event=cpu, `PerfEvents::supported` is false & `record_cpu/target_cpu` is true

For the last case async-profiler would have previously selected ctimer but after change in #1654, async-profiler will select perf events

So the previous change was incomplete, as this branch was in need to be updated to allow the third case to switch the alluser flag if needed

### Related issues
N/A

### Motivation and context
enhance UX by automatically switching the alluser flag in case event=cpu & kernel symbols are not available 

### How has this been tested?
manual, `make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
