### PR TITLE
Fix test failures when restrictions exist on kernel symbols 

### DIFF
--- a/test/test/jfr/JfrTests.java
+++ b/test/test/jfr/JfrTests.java
@@ -42,7 +42,7 @@ public class JfrTests {
         assert out.contains(normalLoadPattern);
     }
 
-    @Test(mainClass = CpuLoad.class, agentArgs = "start,event=cpu,wall,record-cpu,file=%profile.jfr", os = Os.LINUX)
+    @Test(mainClass = CpuLoad.class, agentArgs = "start,event=cpu,alluser,wall,record-cpu,file=%profile.jfr", os = Os.LINUX)
     public void recordCpuMultiEngine(TestProcess p) throws Exception {
         p.waitForExit();
         assert p.exitCode() == 0;


### PR DESCRIPTION
### Description
Currently recordCpuMultiEngine uses `event=cpu` this means that the `alluser` flag will never be automatically turned on if needed 

`_alluser = strcmp(args._event, EVENT_CPU) != 0 && !supported();`

This change selects the `alluser` flag to allow the test to pass even if restrictions exist on kernel symbols 

Note: this won't happen if user selects `event=cpu-clock` as that would automatically change the `alluser` flag, however we wish to keep `event=cpu` here to execute the new code path created here #1654

### Related issues
N/A

### Motivation and context
Allow test to pass even if restrictions exist on kernel symbols

### How has this been tested?
`make test`


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
