### PR TITLE
Change package of the converter Main class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ build/$(API_JAR): $(API_SOURCES) $(JAR_MANIFEST)
 build/$(CONVERTER_JAR): $(CONVERTER_SOURCES) $(RESOURCES)
 	mkdir -p build/converter
 	$(JAVAC) $(JAVAC_OPTIONS) -d build/converter $(CONVERTER_SOURCES)
-	$(JAR) cfe $@ Main -C build/converter . -C src/res .
+	$(JAR) cfe $@ one.convert.Main -C build/converter . -C src/res .
 	$(RM) -r build/converter
 
 %.class: %.java

--- a/pom-converter.xml
+++ b/pom-converter.xml
@@ -57,7 +57,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>Main</mainClass>
+                            <mainClass>one.convert.Main</mainClass>
                         </manifest>
                     </archive>
                 </configuration>

--- a/src/converter/one/convert/Main.java
+++ b/src/converter/one/convert/Main.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import one.convert.*;
+package one.convert;
 
 import java.io.File;
 import java.io.FileInputStream;


### PR DESCRIPTION
### Description

Move converter Main class to the `one.convert` package.

### Related issues

n/a

### Motivation and context

Make it possible to use converter in tests without starting a new process.
Allow embedding converter in other Java applications.

### How has this been tested?

`jfrconv` binary works and so does `java -jar jfr-converter.jar`.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
