### PR TITLE
Remove duplicate CodeCache lookup operation in walkVM

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -409,7 +409,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
             }
         } else {
             native_lib = profiler->findLibraryByAddress(pc);
-            const char* method_name = native_lib != NULL ? native_lib ->binarySearch(pc) : NULL;
+            const char* method_name = native_lib != NULL ? native_lib->binarySearch(pc) : NULL;
             char mark;
             if (method_name != NULL && (mark = NativeFunc::mark(method_name)) != 0) {
                 if (mark == MARK_ASYNC_PROFILER && (event_type == MALLOC_SAMPLE || event_type == NATIVE_LOCK_SAMPLE)) {


### PR DESCRIPTION
### Description
In VM stack walking we use dwarf stack walking to walk the native stacks, this in turn requires looking for the correct FDE that is relevant for the current PC

This operation requires finding the CodeCache that this PC belongs to, which is done via a linear search algorithm 

```
CodeCache* Profiler::findLibraryByAddress(const void* address) {
    const int native_lib_count = _native_libs.count();
    for (int i = 0; i < native_lib_count; i++) {
        if (_native_libs[i]->contains(address)) {
            return _native_libs[i];
        }
    }
    return NULL;
}
```

The problem here is when walking the native stack we also need to resolve the method name, which also requires finding the CodeCache, so in practice when hitting a native method the profiler would end up doing this linear search twice 

This effect can be easily noticed by artificially adding hundreds of shared objects to the app & then calling methods that are declared on the last shared object that was opened 

When doing that on such a custom app I noticed that the total stack walking time for a 15s session was around `50ms`, after applying the changes below the stack walking time came down to around `30ms` for the same app 

Note: for faster stack walking time we can avoid the method name resolution completely & resolve the actual method name during the dumping of stacks, but this does have some caveats that need to be investigated 
* It will increase the CPU overhead for the background timer thread 
* It might cause confusion when it comes for the "stackdepth" as it will be changed to become true stackdepth rather than the truncated stack depth (In malloc & alloc samples we cutoff top frames & reset depth)

### Related issues
N/A

### Motivation and context
Enhance stack walking time by avoiding duplicate lookups for the code cache

### How has this been tested?
Manual testing

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
