### PR TITLE
Unwind AArch64 generated stubs on JDK 26+

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -117,6 +117,10 @@ void Profiler::addJavaMethod(const void* address, int length, jmethodID method) 
 }
 
 void Profiler::addRuntimeStub(const void* address, int length, const char* name) {
+    if (name[0] == 'S' && strncmp(name, "Stub Generator ", 15) == 0) {
+        name += 15;  // useless prefix introduced with JDK-8336658
+    }
+
     _stubs_lock.lock();
     _runtime_stubs.add(address, length, name, true);
     _stubs_lock.unlock();


### PR DESCRIPTION
### Description

1. Strip `Stub Generator` prefix introduced with JDK-8336658.
2. Change `strcmp` to `strncmp` to account for stub suffices added in JDK 26 and JDK 27.
3. Remove dead code related to AsyncGetCallTrace.

### Related issues

`RecoveryTests.intrinsics` fails on JDK 26.

### Motivation and context

Fix unwinding of runtime stubs on JDK 26 / ARM64.

### How has this been tested?

Integration tests pass on JDK 26 and 27-ea.
Manually profiled spring-petclinic and searched for stubs.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
