### PR TITLE
Migrate existing users from dwarf & fp stack walkers to vm if available

### DIFF
--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -253,6 +253,7 @@ Error Arguments::parse(const char* args) {
                     if (strstr(value, "vtable"))   _features.vtable_target = 1;
                     if (strstr(value, "comptask")) _features.comp_task = 1;
                     if (strstr(value, "pcaddr"))   _features.pc_addr = 1;
+                    if (strstr(value, "agct"))     _features.agct = 1;
                 }
 
             CASE("file")

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -254,6 +254,7 @@ Error Arguments::parse(const char* args) {
                     if (strstr(value, "comptask")) _features.comp_task = 1;
                     if (strstr(value, "pcaddr"))   _features.pc_addr = 1;
                     if (strstr(value, "agct"))     _features.agct = 1;
+                    if (strstr(value, "nonative")) _features.no_native = 1;
                 }
 
             CASE("file")

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -254,7 +254,7 @@ Error Arguments::parse(const char* args) {
                     if (strstr(value, "comptask")) _features.comp_task = 1;
                     if (strstr(value, "pcaddr"))   _features.pc_addr = 1;
                     if (strstr(value, "agct"))     _features.agct = 1;
-                    if (strstr(value, "nonative")) _features.no_native = 1;
+                    if (strstr(value, "javaonly")) _features.java_only = 1;
                 }
 
             CASE("file")
@@ -329,7 +329,7 @@ Error Arguments::parse(const char* args) {
                         _cstack = CSTACK_VM;
                         _features.mixed = 1;
                     } else {
-                        _features.no_native = 1;
+                        _features.java_only = 1;
                     }
                 }
 

--- a/src/arguments.cpp
+++ b/src/arguments.cpp
@@ -329,7 +329,7 @@ Error Arguments::parse(const char* args) {
                         _cstack = CSTACK_VM;
                         _features.mixed = 1;
                     } else {
-                        _cstack = CSTACK_NO;
+                        _features.no_native = 1;
                     }
                 }
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -112,7 +112,8 @@ struct StackWalkFeatures {
     unsigned short vtable_target : 1;   // show receiver classes of vtable/itable stubs
     unsigned short comp_task     : 1;   // display current compilation task for JIT threads
     unsigned short pc_addr       : 1;   // record exact PC address for each sample
-    unsigned short _padding      : 9;   // pad structure to 16 bits
+    unsigned short no_native     : 1;   // do not collect native stacks
+    unsigned short _padding      : 8;   // pad structure to 16 bits
 };
 
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -107,11 +107,12 @@ constexpr int EVENT_MASK_SIZE = 7;
 struct StackWalkFeatures {
     unsigned short stats         : 1;   // collect stack walking duration statistics
     unsigned short jnienv        : 1;   // verify JNIEnv* obtained using VMStructs
+    unsigned short agct          : 1;   // force usage of legacy stack walkers when selected rather than silently using vm
     unsigned short mixed         : 1;   // mixed stack traces with Java and native frames interleaved
     unsigned short vtable_target : 1;   // show receiver classes of vtable/itable stubs
     unsigned short comp_task     : 1;   // display current compilation task for JIT threads
     unsigned short pc_addr       : 1;   // record exact PC address for each sample
-    unsigned short _padding      : 10;  // pad structure to 16 bits
+    unsigned short _padding      : 9;   // pad structure to 16 bits
 };
 
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -60,7 +60,6 @@ enum SHORT_ENUM CStack {
     CSTACK_FP,       // walk stack using Frame Pointer links
     CSTACK_DWARF,    // use DWARF unwinding info from .eh_frame section
     CSTACK_VM,       // unwind using HotSpot VMStructs
-    CSTACK_INVALID   // added to stop compilation warning related to assert statement in flightRecorder
 };
 
 enum SHORT_ENUM Clock {
@@ -112,7 +111,7 @@ struct StackWalkFeatures {
     unsigned short vtable_target : 1;   // show receiver classes of vtable/itable stubs
     unsigned short comp_task     : 1;   // display current compilation task for JIT threads
     unsigned short pc_addr       : 1;   // record exact PC address for each sample
-    unsigned short no_native     : 1;   // do not collect native stacks
+    unsigned short java_only     : 1;   // only collect java stacks
     unsigned short _padding      : 8;   // pad structure to 16 bits
 };
 

--- a/src/arguments.h
+++ b/src/arguments.h
@@ -57,10 +57,10 @@ enum Style {
 // Whenever enum changes, update SETTING_CSTACK in FlightRecorder
 enum SHORT_ENUM CStack {
     CSTACK_DEFAULT,  // use perf_event_open stack if available or Frame Pointer links otherwise
-    CSTACK_NO,       // do not collect native frames
     CSTACK_FP,       // walk stack using Frame Pointer links
     CSTACK_DWARF,    // use DWARF unwinding info from .eh_frame section
-    CSTACK_VM        // unwind using HotSpot VMStructs
+    CSTACK_VM,       // unwind using HotSpot VMStructs
+    CSTACK_INVALID   // added to stop compilation warning related to assert statement in flightRecorder
 };
 
 enum SHORT_ENUM Clock {

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -18,6 +18,7 @@ CpuEngine* CpuEngine::_current = NULL;
 
 long CpuEngine::_interval;
 CStack CpuEngine::_cstack;
+StackWalkFeatures CpuEngine::_features;
 int CpuEngine::_signal;
 bool CpuEngine::_count_overrun;
 
@@ -124,7 +125,7 @@ void CpuEngine::signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext) {
     if (!_enabled) return;
 
     J9StackTraceNotification notif;
-    notif.num_frames = _cstack == CSTACK_NO ? 0 : _cstack == CSTACK_DWARF
+    notif.num_frames = _features.no_native ? 0 : _cstack == CSTACK_DWARF
         ? StackWalker::walkDwarf(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES)
         : StackWalker::walkFP(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES);
     J9StackTraces::checkpoint(_interval, &notif);

--- a/src/cpuEngine.cpp
+++ b/src/cpuEngine.cpp
@@ -125,7 +125,7 @@ void CpuEngine::signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext) {
     if (!_enabled) return;
 
     J9StackTraceNotification notif;
-    notif.num_frames = _features.no_native ? 0 : _cstack == CSTACK_DWARF
+    notif.num_frames = _features.java_only ? 0 : _cstack == CSTACK_DWARF
         ? StackWalker::walkDwarf(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES)
         : StackWalker::walkFP(ucontext, notif.addr, MAX_J9_NATIVE_FRAMES);
     J9StackTraces::checkpoint(_interval, &notif);

--- a/src/cpuEngine.h
+++ b/src/cpuEngine.h
@@ -15,6 +15,7 @@ class CpuEngine : public Engine {
   protected:
     static void** _pthread_entry;
     static CpuEngine* _current;
+    static StackWalkFeatures _features;
 
     static long _interval;
     static CStack _cstack;

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -4,7 +4,6 @@
  */
 
 #ifdef __linux__
-#include "cpuEngine.h"
 
 #include <stdlib.h>
 #include <sys/syscall.h>

--- a/src/ctimer_linux.cpp
+++ b/src/ctimer_linux.cpp
@@ -4,6 +4,7 @@
  */
 
 #ifdef __linux__
+#include "cpuEngine.h"
 
 #include <stdlib.h>
 #include <sys/syscall.h>
@@ -83,6 +84,7 @@ Error CTimer::start(Arguments& args) {
     }
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
     _cstack = args._cstack;
+    _features = args._features;
     _signal = args._signal == 0 ? OS::getProfilingSignal(0) : args._signal & 0xff;
     _count_overrun = true;
 

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -629,7 +629,7 @@ class Recording {
 
     void writeSettings(Buffer* buf, Arguments& args) {
         const char* const* cstack_str = SETTING_CSTACK + args._cstack;
-        const char* const* cstack_limit = SETTING_CSTACK + sizeof(SETTING_CSTACK);
+        const char* const* cstack_limit = SETTING_CSTACK + (sizeof(SETTING_CSTACK) / sizeof(char*));
         assert(cstack_str < cstack_limit);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "version", PROFILER_VERSION);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "engine", Profiler::instance()->_engine->type());

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -628,10 +628,12 @@ class Recording {
     }
 
     void writeSettings(Buffer* buf, Arguments& args) {
-        assert(args._cstack < sizeof(SETTING_CSTACK) / sizeof(char*));
+        const char* const* cstack_str = SETTING_CSTACK + args._cstack;
+        const char* const* cstack_limit = SETTING_CSTACK + sizeof(SETTING_CSTACK);
+        assert(cstack_str < cstack_limit);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "version", PROFILER_VERSION);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "engine", Profiler::instance()->_engine->type());
-        writeStringSetting(buf, T_ACTIVE_RECORDING, "cstack", SETTING_CSTACK[args._cstack]);
+        writeStringSetting(buf, T_ACTIVE_RECORDING, "cstack", *cstack_str);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "clock", TSC::enabled() ? "tsc" : "monotonic");
         writeStringSetting(buf, T_ACTIVE_RECORDING, "event", args._event);
         writeStringSetting(buf, T_ACTIVE_RECORDING, "filter", args._filter);

--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -60,7 +60,7 @@ static jmethodID _stop_method;
 static jmethodID _box_method;
 static bool _jfr_starting = false;
 
-static const char* const SETTING_CSTACK[] = {NULL, "no", "fp", "dwarf", "vm"};
+static const char* const SETTING_CSTACK[] = {NULL, "fp", "dwarf", "vm"};
 
 
 struct CpuTime {

--- a/src/itimer.cpp
+++ b/src/itimer.cpp
@@ -16,6 +16,7 @@ Error ITimer::start(Arguments& args) {
     }
     _interval = args._interval ? args._interval : DEFAULT_INTERVAL;
     _cstack = args._cstack;
+    _features = args._features;
     _signal = SIGPROF;
     _count_overrun = false;
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -59,7 +59,7 @@ static const char USAGE_STRING[] =
     "  -I include          output only stack traces containing the specified pattern\n"
     "  -X exclude          exclude stack traces with the specified pattern\n"
     "  -L level            log level: debug|info|warn|error|none\n"
-    "  -F features         advanced stack trace features: mixed, vtable, comptask, pcaddr\n"
+    "  -F features         advanced stack trace features: nonative, mixed, vtable, comptask, pcaddr\n"
     "  -v, --version       display version string\n"
     "\n"
     "  --title string      FlameGraph title\n"

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -59,7 +59,7 @@ static const char USAGE_STRING[] =
     "  -I include          output only stack traces containing the specified pattern\n"
     "  -X exclude          exclude stack traces with the specified pattern\n"
     "  -L level            log level: debug|info|warn|error|none\n"
-    "  -F features         advanced stack trace features: nonative, mixed, vtable, comptask, pcaddr\n"
+    "  -F features         advanced stack trace features: javaonly, mixed, vtable, comptask, pcaddr\n"
     "  -v, --version       display version string\n"
     "\n"
     "  --title string      FlameGraph title\n"

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -4,6 +4,8 @@
  */
 
 #ifdef __linux__
+#include "cpuEngine.h"
+#include "cpuEngine.h"
 
 #include <jvmti.h>
 #include <string.h>
@@ -785,7 +787,7 @@ void PerfEvents::signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext) 
         u64 counter = readCounter(siginfo, ucontext);
         J9StackTraceNotification notif;
         u64 cpu = 0;
-        notif.num_frames = _cstack == CSTACK_NO ? 0 : walk(OS::threadId(), ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &cpu);
+        notif.num_frames = _features.no_native ? 0 : walk(OS::threadId(), ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &cpu);
         J9StackTraces::checkpoint(counter, &notif);
     } else {
         resetBuffer(OS::threadId());
@@ -829,11 +831,12 @@ Error PerfEvents::start(Arguments& args) {
     }
     _interval = args._interval ? args._interval : _event_type->default_interval;
     _cstack = args._cstack;
+    _features = args._features;
     _signal = args._signal == 0 ? OS::getProfilingSignal(0) : args._signal & 0xff;
     _count_overrun = false;
 
     _alluser = args._alluser;
-    _kernel_stack = !_alluser && _cstack != CSTACK_NO;
+    _kernel_stack = !_alluser && !_features.no_native;
     if (_kernel_stack && !Symbols::haveKernelSymbols()) {
         Log::warn("Kernel symbols are unavailable due to restrictions. Try\n"
                   "  sysctl kernel.perf_event_paranoid=1\n"

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -4,8 +4,6 @@
  */
 
 #ifdef __linux__
-#include "cpuEngine.h"
-#include "cpuEngine.h"
 
 #include <jvmti.h>
 #include <string.h>

--- a/src/perfEvents_linux.cpp
+++ b/src/perfEvents_linux.cpp
@@ -785,7 +785,7 @@ void PerfEvents::signalHandlerJ9(int signo, siginfo_t* siginfo, void* ucontext) 
         u64 counter = readCounter(siginfo, ucontext);
         J9StackTraceNotification notif;
         u64 cpu = 0;
-        notif.num_frames = _features.no_native ? 0 : walk(OS::threadId(), ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &cpu);
+        notif.num_frames = _features.java_only ? 0 : walk(OS::threadId(), ucontext, notif.addr, MAX_J9_NATIVE_FRAMES, &cpu);
         J9StackTraces::checkpoint(counter, &notif);
     } else {
         resetBuffer(OS::threadId());
@@ -834,7 +834,7 @@ Error PerfEvents::start(Arguments& args) {
     _count_overrun = false;
 
     _alluser = args._alluser;
-    _kernel_stack = !_alluser && !_features.no_native;
+    _kernel_stack = !_alluser && !_features.java_only;
     if (_kernel_stack && !Symbols::haveKernelSymbols()) {
         Log::warn("Kernel symbols are unavailable due to restrictions. Try\n"
                   "  sysctl kernel.perf_event_paranoid=1\n"

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -937,14 +937,11 @@ Error Profiler::start(Arguments& args, bool reset) {
         return Error("VMStructs stack walking is not supported on this JVM/platform");
     }
 
-    if (_cstack == CSTACK_DEFAULT) {
-        if (VMStructs::hasStackStructs()) {
-            // Use VMStructs by default when possible
-            _cstack = args._cstack = CSTACK_VM;
-        } else if (VM::isOpenJ9() && DWARF_SUPPORTED) {
-            // OpenJ9 libs are compiled with frame pointers omitted
-            _cstack = args._cstack = CSTACK_DWARF;
-        }
+    if (VMStructs::hasStackStructs() && !_features.agct) {
+        _cstack = CSTACK_VM;
+    } else if (_cstack == CSTACK_DEFAULT && VM::isOpenJ9() && DWARF_SUPPORTED) {
+        // OpenJ9 libs are compiled with frame pointers omitted
+        _cstack = args._cstack = CSTACK_DWARF;
     }
 
     if (_cstack != CSTACK_VM && _features.mixed) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -938,7 +938,7 @@ Error Profiler::start(Arguments& args, bool reset) {
     }
 
     if (VMStructs::hasStackStructs() && !_features.agct) {
-        _cstack = CSTACK_VM;
+        _cstack = args._cstack = CSTACK_VM;
     } else if (_cstack == CSTACK_DEFAULT && VM::isOpenJ9() && DWARF_SUPPORTED) {
         // OpenJ9 libs are compiled with frame pointers omitted
         _cstack = args._cstack = CSTACK_DWARF;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -426,7 +426,7 @@ u64 Profiler::recordSample(void* ucontext, u64 counter, EventType event_type, Ev
         if (_features.pc_addr && event_type <= WALL_CLOCK_SAMPLE) {
             num_frames += makeFrame(frames + num_frames, BCI_ADDRESS, StackFrame(ucontext).pc());
         }
-        if (_cstack != CSTACK_NO) {
+        if (!_features.no_native || _cstack != CSTACK_NO) {
             num_frames += getNativeTrace(ucontext, frames + num_frames, event_type, tid, &cpu);
         }
     }
@@ -869,6 +869,18 @@ Error Profiler::start(Arguments& args, bool reset) {
     // Save the arguments for shutdown or restart
     args.save();
 
+    _features = args._features;
+    if (!VMStructs::hasClassNames()) {
+        _features.vtable_target = 0;
+    }
+    if (!VMStructs::hasCompilerStructs()) {
+        _features.comp_task = 0;
+    }
+
+    if (args._cstack == CSTACK_NO) {
+        _features.no_native = 1;
+    }
+
     if (reset || _start_time == 0) {
         // Reset counters
         _total_samples = 0;
@@ -884,7 +896,7 @@ Error Profiler::start(Arguments& args, bool reset) {
         _add_event_frame = args._output != OUTPUT_JFR;
         _add_thread_frame = args._threads && args._output != OUTPUT_JFR;
         _add_sched_frame = args._sched;
-        _add_cpu_frame = args._record_cpu;
+        _add_cpu_frame = args._record_cpu && !_features.no_native;
         unlockAll();
 
         // Reset thread names and IDs
@@ -906,14 +918,6 @@ Error Profiler::start(Arguments& args, bool reset) {
                 return Error("Not enough memory to allocate stack trace buffers (try smaller jstackdepth)");
             }
         }
-    }
-
-    _features = args._features;
-    if (!VMStructs::hasClassNames()) {
-        _features.vtable_target = 0;
-    }
-    if (!VMStructs::hasCompilerStructs()) {
-        _features.comp_task = 0;
     }
 
     _update_thread_names = args._threads || args._output == OUTPUT_JFR;

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -428,7 +428,7 @@ u64 Profiler::recordSample(void* ucontext, u64 counter, EventType event_type, Ev
         if (_features.pc_addr && event_type <= WALL_CLOCK_SAMPLE) {
             num_frames += makeFrame(frames + num_frames, BCI_ADDRESS, StackFrame(ucontext).pc());
         }
-        if (!_features.no_native) {
+        if (!_features.java_only) {
             num_frames += getNativeTrace(ucontext, frames + num_frames, event_type, tid, &cpu);
         }
     }
@@ -894,7 +894,7 @@ Error Profiler::start(Arguments& args, bool reset) {
         _add_event_frame = args._output != OUTPUT_JFR;
         _add_thread_frame = args._threads && args._output != OUTPUT_JFR;
         _add_sched_frame = args._sched;
-        _add_cpu_frame = args._record_cpu && !_features.no_native;
+        _add_cpu_frame = args._record_cpu && !_features.java_only;
         unlockAll();
 
         // Reset thread names and IDs

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -428,7 +428,7 @@ u64 Profiler::recordSample(void* ucontext, u64 counter, EventType event_type, Ev
         if (_features.pc_addr && event_type <= WALL_CLOCK_SAMPLE) {
             num_frames += makeFrame(frames + num_frames, BCI_ADDRESS, StackFrame(ucontext).pc());
         }
-        if (!_features.no_native || _cstack != CSTACK_NO) {
+        if (!_features.no_native) {
             num_frames += getNativeTrace(ucontext, frames + num_frames, event_type, tid, &cpu);
         }
     }
@@ -877,10 +877,6 @@ Error Profiler::start(Arguments& args, bool reset) {
     }
     if (!VMStructs::hasCompilerStructs()) {
         _features.comp_task = 0;
-    }
-
-    if (args._cstack == CSTACK_NO) {
-        _features.no_native = 1;
     }
 
     if (reset || _start_time == 0) {

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -235,7 +235,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
 
     // Show extended frame types and stub frames for execution-type events
     bool details = event_type <= MALLOC_SAMPLE || features.mixed;
-    bool no_native = features.no_native;
+    bool java_only = features.java_only;
 
     JavaFrameAnchor* anchor = NULL;
     VMThread* vm_thread = VMThread::current();
@@ -250,7 +250,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
     }
 
     // Jump directly to java frame if possible in case native frames are not desired
-    if (no_native && anchor != NULL) {
+    if (java_only && anchor != NULL) {
         anchor->restoreFrame(pc, sp, fp);
         anchor = NULL;
     }
@@ -395,7 +395,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                 const void* start = stub != NULL ? stub->_start : nm->code();
                 const char* name = stub != NULL ? stub->_name : nm->name();
 
-                if (!no_native && details) {
+                if (!java_only && details) {
                     fillFrame(frames[depth++], BCI_NATIVE_FRAME, name);
                 }
 
@@ -412,7 +412,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
             }
         } else {
             native_lib = profiler->findLibraryByAddress(pc);
-            if (!no_native) {
+            if (!java_only) {
                 const char* method_name = native_lib != NULL ? native_lib->binarySearch(pc) : NULL;
                 char mark;
                 if (method_name != NULL && (mark = NativeFunc::mark(method_name)) != 0) {

--- a/test/test/alloc/AllocTests.java
+++ b/test/test/alloc/AllocTests.java
@@ -43,7 +43,7 @@ public class AllocTests {
         assert out.contains("java\\.util\\.HashMap\\$Node\\[]");
     }
 
-    @Test(mainClass = Hello.class, agentArgs = "start,event=alloc,alloc=1,cstack=fp,flamegraph,file=%f", jvmArgs = "-XX:+UseG1GC -XX:-UseTLAB")
+    @Test(mainClass = Hello.class, agentArgs = "start,event=alloc,alloc=1,cstack=fp,features=agct,flamegraph,file=%f", jvmArgs = "-XX:+UseG1GC -XX:-UseTLAB")
     public void startup(TestProcess p) throws Exception {
         Output out = p.waitForExit("%f");
         out = out.convertFlameToCollapsed();

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -26,6 +26,16 @@ public class CstackTests {
         assert out.contains("LongInitializer.main_\\[j]");
     }
 
+    @Test(mainClass = LongInitializer.class, jvm = Jvm.HOTSPOT)
+    public void noNative(TestProcess p) throws Exception {
+        Output out = p.profile(PROFILE_COMMAND + "--cstack no");
+        assert !out.contains(";readBytes");
+        assert out.contains("LongInitializer.main_\\[0]");
+        assert !out.contains("InstanceKlass::initialize");
+        assert !out.contains("call_stub");
+        assert !out.contains("JavaMain");
+    }
+
     @Test(mainClass = LongInitializer.class, jvm = Jvm.HOTSPOT, os = Os.LINUX)
     public void vmStructs(TestProcess p) throws Exception {
         Output out = p.profile(PROFILE_COMMAND + "--cstack vm");

--- a/test/test/cstack/CstackTests.java
+++ b/test/test/cstack/CstackTests.java
@@ -17,11 +17,11 @@ public class CstackTests {
 
     @Test(mainClass = LongInitializer.class)
     public void asyncGetCallTrace(TestProcess p) throws Exception {
-        Output out = p.profile(PROFILE_COMMAND + "--cstack no");
+        Output out = p.profile(PROFILE_COMMAND + "--cstack no --features agct");
         assert !out.contains(";readBytes");
         assert out.contains("LongInitializer.main_\\[j]");
 
-        out = p.profile(PROFILE_COMMAND + "--cstack fp");
+        out = p.profile(PROFILE_COMMAND + "--cstack fp --features agct");
         assert out.contains(";readBytes");
         assert out.contains("LongInitializer.main_\\[j]");
     }


### PR DESCRIPTION
### Description
While working on #1676 many challenges were observed, these are mainly related to differences between hotspot & openj9 JDKs in terms of how the stack is collected 

Merging the code is doable but will require many changes that will make the code highly unmergable without spreading the change across multiple PRs

Even after the change we will end up with effectively a larger codebase as the savings acquired by cleaning up DWARF function will be largely overshadowed by the changes needed to address J9 side of the stack walking 

As such as discussed internally it's a better idea to simply move existing users of the async-profiler to use VM when available & only expose legacy stack walkers via a new feature flag that is off by default

As part of this change the `no` stackwalker was replaced to use VM if available & fallback to agct if not

### Related issues
N/A

### Motivation and context
Move users to the better VM stack walker if available

### How has this been tested?
`make test`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
