### PR TITLE
fix parsing os thread state

### DIFF
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -213,7 +213,7 @@ ThreadState OS::threadState(int thread_id) {
 
     ThreadState state = THREAD_UNKNOWN;
     if (read(fd, buf, sizeof(buf)) > 0) {
-        char* s = strchr(buf, ')');
+        char* s = strrchr(buf, ')');
         state = s != NULL && (s[2] == 'R' || s[2] == 'D') ? THREAD_RUNNING : THREAD_SLEEPING;
     }
 


### PR DESCRIPTION
### Description
I believe `::threadState`, should search for the last `)` when parsing thread state, consider this thread:
```
48485 (qwe239 :))) R 46567 48485 46567 0 -1 4194304 303 0 0 0 0 9 0 0 20 0 1 0 9683058 2486272 366 18446744073709551615 4194304 4195981 140727413481632 0 0 0 4 0 0 0 0 0 17 2 0 0 0 0 0 4206072 4206668 681123840 140727413483550 140727413483619 140727413483619 140727413485491 0
```

### Related issues


### Motivation and context
Currently all threads with `)` in the name are treated as `THREAD_SLEEPING`

### How has this been tested?

```diff
diff --git a/src/os.h b/src/os.h
index 0ad8b1e..59e7a53 100644
--- a/src/os.h
+++ b/src/os.h
@@ -114,6 +114,9 @@ class OS {
     static const char* schedPolicy(int thread_id);
     static bool threadName(int thread_id, char* name_buf, size_t name_len);
     static ThreadState threadState(int thread_id);
+#ifdef __linux__
+    static ThreadState parseLinuxThreadState(const char *buf);
+#endif
     static u64 threadCpuTime(int thread_id);
     static ThreadList* listThreads();

diff --git a/src/os_linux.cpp b/src/os_linux.cpp
index c2d4894..67706f4 100644
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -203,6 +203,11 @@ bool OS::threadName(int thread_id, char* name_buf, size_t name_len) {
     return false;
 }

+ThreadState OS::parseLinuxThreadState(const char *buf) {
+    const char* s = strrchr(buf, ')');
+    return s != NULL && (s[2] == 'R' || s[2] == 'D') ? THREAD_RUNNING : THREAD_SLEEPING;
+}
+
 ThreadState OS::threadState(int thread_id) {
     char buf[512];
     snprintf(buf, sizeof(buf), "/proc/self/task/%d/stat", thread_id);
@@ -213,8 +218,7 @@ ThreadState OS::threadState(int thread_id) {

     ThreadState state = THREAD_UNKNOWN;
     if (read(fd, buf, sizeof(buf)) > 0) {
-        char* s = strrchr(buf, ')');
-        state = s != NULL && (s[2] == 'R' || s[2] == 'D') ? THREAD_RUNNING : THREAD_SLEEPING;
+        state = parseLinuxThreadState(buf);
     }

     close(fd);
diff --git a/test/native/processInfoTest.cpp b/test/native/processInfoTest.cpp
index 14ae56d..054979d 100644
--- a/test/native/processInfoTest.cpp
+++ b/test/native/processInfoTest.cpp
@@ -123,6 +123,13 @@ TEST_CASE(ClockTicksPerSec_is_valid) {
     ASSERT_LTE(OS::clock_ticks_per_sec, 10000L);
 }

+TEST_CASE(ThreadState) {
+    ASSERT_EQ(THREAD_RUNNING, OS::parseLinuxThreadState("53568 (cat) R 53532OS::threadState ..."));
+    ASSERT_EQ(THREAD_SLEEPING, OS::parseLinuxThreadState("53568 (cat) S 53532 ..."));
+    ASSERT_EQ(THREAD_SLEEPING, OS::parseLinuxThreadState("53568 (cat :)) S 53532 ..."));
+    ASSERT_EQ(THREAD_RUNNING, OS::parseLinuxThreadState("53568 (cat :)) R 53532 ..."));
+}
+
 #else

 TEST_CASE(ProcessInfo_functions_not_implemented_on_non_linux) {
```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
