### PR TITLE
Ensure remaining buffer is sufficient for event data in JfrReader

### DIFF
--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -181,8 +181,6 @@ public class JfrReader implements Closeable {
                 }
                 return null;
             }
-            long eventEnd = filePosition + pos + size;
-            ensureBytes(size - (buf.position() - pos));
 
             if (type == executionSample || type == nativeMethodSample) {
                 if (cls == null || cls == ExecutionSample.class) return (E) readExecutionSample(false);
@@ -213,6 +211,8 @@ public class JfrReader implements Closeable {
             } else {
                 Constructor<? extends Event> customEvent = customEvents.get(type);
                 if (customEvent != null && (cls == null || cls == customEvent.getDeclaringClass())) {
+                    long eventEnd = filePosition + pos + size;
+                    ensureBytes(size - (buf.position() - pos));
                     try {
                         return (E) customEvent.newInstance(this);
                     } catch (ReflectiveOperationException e) {
@@ -223,7 +223,7 @@ public class JfrReader implements Closeable {
                 }
             }
 
-            seek(eventEnd);
+            seek(filePosition + pos + size);
         }
 
         state = STATE_EOF;


### PR DESCRIPTION
### Description

`JfrReader.readEvent()` only calls `ensureBytes(CHUNK_HEADER_SIZE)` (68 bytes) at the top of its read loop. It does not ensure the buffer contains enough data for the full event before dispatching to event readers. If an event exceeds the remaining buffer capacity, the read methods (`getString()` in my example) throw `BufferUnderflowException`. 

Any event larger than 68 bytes is technically susceptible, including, I believe, the new `ProcessSample`. Although an event close to 68 bytes should rare hit this in practice.

#### Reproducer

See my [branch](https://github.com/alevymyers/async-profiler/commit/1c084fc48f8049a4f8949bafa2e9c22cb27726da) with a naive reproducer that can create a JFR with a ThreadDump event exceeding the default buffer size. Along with that, the required changes to cause the error in `JfrReader` and `JfrConverter`. 

### Related issues


### Motivation and context

Will crash under certain conditions if the code is extended, in a way that is supported.

### How has this been tested?

Verified using the reproducer branch and confirmed the `BufferUnderflowException` before the fix and successfully reading the JFR after.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
