### PR TITLE
Allow negative keys in JFR constant pool

### DIFF
--- a/src/converter/one/jfr/Dictionary.java
+++ b/src/converter/one/jfr/Dictionary.java
@@ -12,6 +12,7 @@ import java.util.Arrays;
  */
 public class Dictionary<T> {
     private static final int INITIAL_CAPACITY = 16;
+    private static final long USED_BIT = 1L << 63;
 
     private long[] keys;
     private Object[] values;
@@ -37,12 +38,12 @@ public class Dictionary<T> {
     }
 
     // key[i]==0 is used to signal that the i-th position is unset.
-    // Thus, we map key=key+1, so the user can still use key=0.
+    // Thus, we flip USED_BIT, so the user can still use key=0.
     private static long remapKey(long key) {
-        if (key < 0) {
-            throw new IllegalArgumentException("Negative keys not allowed");
+        if (key == USED_BIT) {
+            throw new IllegalArgumentException("Key not allowed");
         }
-        return key + 1;
+        return key ^ USED_BIT;
     }
 
     public void put(long key, T value) {
@@ -82,7 +83,7 @@ public class Dictionary<T> {
         for (int i = 0; i < keys.length; i++) {
             if (keys[i] != 0) {
                 // Map key back, see remapKey
-                visitor.visit(keys[i] - 1, (T) values[i]);
+                visitor.visit(keys[i] ^ USED_BIT, (T) values[i]);
             }
         }
     }


### PR DESCRIPTION
### Description

`Dictionary` - which is essentially a long->Object hash map - does not currently allow keys < 0.
This PR makes it possible to use negative keys, except for one reserved value: `0x8000000000000000` (`Long.MIN_VALUE`).

### Motivation and context

`Dictionary` class is used by `JfrReader` to store items from JFR constant pools: threads, classes, stack traces, etc. Pooled strings are also saved in a  dedicated `Dictionary`.

We've seen a valid JFR where String pool contains exactly one element with ID = -1. Even though JDK Flight Recorder is not supposed to emit constant pool elements with negative IDs, async-profiler's JfrReader should not crash if it encounters such a key.

### How has this been tested?

Manually ran `jfrconv` on a problematic .jfr recording that has a String with negative ID.
Integration tests pass.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
