### PR TITLE
Reattempt stack walking using Framepointer in case link register fails to unwind the stack  

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -424,6 +424,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
         }
 
         uintptr_t prev_fp = fp;
+        const void* prev_pc = pc;
         FrameDesc* f = native_lib != NULL ? native_lib->findFrameDesc(pc) : &FrameDesc::default_frame;
 
         unwind_frame:
@@ -449,7 +450,6 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
             break;
         }
 
-        const void* prev_pc = pc;
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -423,8 +423,10 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
             fillFrame(frames[depth++], BCI_NATIVE_FRAME, method_name);
         }
 
+        uintptr_t prev_fp = fp;
         FrameDesc* f = native_lib != NULL ? native_lib->findFrameDesc(pc) : &FrameDesc::default_frame;
 
+        unwind_frame:
         u8 cfa_reg = (u8)f->cfa;
         int cfa_off = f->cfa >> 8;
         if (cfa_reg == DW_REG_SP) {
@@ -457,10 +459,15 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
 
             if (EMPTY_FRAME_SIZE > 0 || f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(*(void**)(sp + f->pc_off));
-            } else if (depth == 1) {
-                pc = (const void*)frame.link();
             } else {
-                break;
+                if (depth == 1) pc = (const void*)frame.link();
+
+                if (pc == prev_pc) {
+                    f = &FrameDesc::default_frame;
+                    sp = prev_sp;
+                    fp = prev_fp;
+                    goto unwind_frame;
+                }
             }
 
             if (EMPTY_FRAME_SIZE == 0 && cfa_off == 0 && f->fp_off != DW_SAME_FP) {


### PR DESCRIPTION
### Description
In some edge cases on ARM (vdso for example) it's possible for the link register to fail in unwinding the stack, this happen in 2 cases 

* Link register results in `pc == prev_pc`
* multiple frames that have to use link register, i.e. `f->pc_off == DW_LINK_REGISTER && depth > 1`

In this change we instruct the stack walker to re-attempt stack walking using FP as a final attempt to recover to a sane state

### Related issues
#1653

### Motivation and context
Enhance stack walking for ARM

### How has this been tested?
make test

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
