### PR TITLE
Add dark mode functionality to flame, tree and heatmap graphs

### DIFF
--- a/src/res/flame.html
+++ b/src/res/flame.html
@@ -3,28 +3,37 @@
 <head>
 <meta charset='utf-8'>
 <style>
-	body {margin: 0; padding: 10px 10px 22px 10px; background-color: #ffffff}
+	:root {--bg-color:#ffffff;--text-color:#000000;--tooltip-bg:#ffffe0;--tooltip-border:#ffc000;--legend-border:#666666;--link-color:#0366d6;--dim-overlay:rgba(255,255,255,0.5)}
+	[data-theme="dark"] {--bg-color:#1e1e1e;--text-color:#d4d4d4;--tooltip-bg:#2d2d2d;--tooltip-border:#555555;--legend-border:#555555;--link-color:#58a6ff;--dim-overlay:rgba(30,30,30,0.5)}
+	.theme-icon-dark {display:none}
+	[data-theme="dark"] .theme-icon-light {display:none}
+	[data-theme="dark"] .theme-icon-dark {display:inline}
+	body {margin: 0; padding: 10px 10px 22px 10px; background-color: var(--bg-color); color: var(--text-color)}
 	h1 {margin: 5px 0 0 0; font-size: 18px; font-weight: normal; text-align: center}
 	header {margin: -22px 0 6px 0}
 	button {border: none; background: none; width: 24px; height: 24px; cursor: pointer; margin: 0; padding: 2px 0 0 0; text-align: center}
-	button:hover {background-color: #ffffe0; outline: 1px solid #ffc000; border-radius: 4px}
+	button:hover {background-color: var(--tooltip-bg); outline: 1px solid var(--tooltip-border); border-radius: 4px}
 	dl {margin: 0 4px 8px 4px}
 	dt {margin: 1px; padding: 2px 0; font-weight: bold}
 	dd {margin: 1px; padding: 2px 4px}
 	dl.frames {float: left; width: 160px}
-	dl.hotkeys {clear: left; border-top: 1px solid #666666}
+	dl.hotkeys {clear: left; border-top: 1px solid var(--legend-border)}
 	dl.hotkeys > dt {float: left; clear: left; width: 158px; margin-right: 4px; text-align: right}
 	dl.hotkeys > dd {float: left}
-	p {position: fixed; bottom: 0; margin: 0; padding: 2px 3px 2px 3px; outline: 1px solid #ffc000; display: none; overflow: hidden; white-space: nowrap; background-color: #ffffe0}
-	a {color: #0366d6}
-	#legend {padding: 4px; border-radius: 4px; background: #ffffe0; border: 1px solid #666666; display: none}
-	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: #ffffe0; outline: 1px solid #ffc000; height: 15px}
+	p {position: fixed; bottom: 0; margin: 0; padding: 2px 3px 2px 3px; outline: 1px solid var(--tooltip-border); display: none; overflow: hidden; white-space: nowrap; background-color: var(--tooltip-bg); color: var(--text-color)}
+	a {color: var(--link-color)}
+	#legend {padding: 4px; border-radius: 4px; background: var(--tooltip-bg); border: 1px solid var(--legend-border); display: none; color: var(--text-color)}
+	#hl {position: absolute; display: none; overflow: hidden; white-space: nowrap; pointer-events: none; background-color: var(--tooltip-bg); outline: 1px solid var(--tooltip-border); height: 15px; color: var(--text-color)}
 	#hl span {padding: 0 3px 0 3px}
 	#status {left: 0}
 	#match {right: 0}
 	#reset {cursor: pointer}
 	#canvas {width: 100%; height: /*height:*/300px}
 </style>
+<script>
+	document.documentElement.dataset.theme = localStorage.getItem('color-mode') ||
+		(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+</script>
 </head>
 <body style='font: 12px Verdana, sans-serif'>
 <h1>/*title:*/</h1>
@@ -32,6 +41,7 @@
 <button id='inverted' title='Invert (I)'><svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 392 392'><path d='M196,36 L316,156 L76,156 Z' fill='#004d80'/><path d='M196,356 L76,236 L316,236 Z' fill='#004d80'/><path d='M196,54 L298,156 L94,156 Z' fill='#ff8d40'/><path d='M196,338 L94,236 L298,236 Z' fill='#40b2ff'/><rect x='94' y='188' width='204' height='16' fill='#004d80'/></svg></button>
 <button id='search' title='Search (Ctrl+F)'><svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='-39.3 -39.3 471.1 471.1'><circle cx='147.7' cy='147.8' r='125.9' fill='#fff'/><path fill='#40b2ff' d='M370.7 348.7c0 1.4-1.6 6.3-7.2 12.3-6.2 6.7-12.5 9.8-14.7 9.8h-.1c-19.5-1.6-62-43.2-109.6-106.8 9.2-7.2 17.5-15.5 24.6-24.6 63.6 47.6 105.2 90.2 106.8 109.6z'/><path fill='#ff8d40' d='M208.7 86.9l-14.5 14.5c-17.1 17.1-46.5 5-46.5-19.3V61.6c-49 0-88.4 40.8-86.1 90.2 2 43.9 38.1 80 82 82 49.5 2.3 90.2-37.2 90.2-86.1 0-23.7-9.6-45.2-25.1-60.8z'/><path fill='#004d80' d='M276.1 221c12.3-21.5 19.5-46.5 19.5-73.2C295.6 66.3 229.2.1 147.7.1S0 66.3 0 147.9s66.3 147.7 147.7 147.7c26.6 0 51.5-7.1 73.2-19.5 39.8 53.3 91.9 113.5 126.1 116.4 12.3.5 22.9-6.7 32.8-16.7 5.2-5.6 13.8-16.9 12.8-28.8-2.9-34.1-63.1-86.2-116.4-126.1zM147.7 273.8c-69.5 0-125.9-56.5-125.9-125.9S78.3 21.9 147.7 21.9 273.6 78.4 273.6 147.8s-56.4 126-125.9 126zm215.9 87.2c-6.2 6.7-12.4 9.8-14.7 9.8h-.1c-19.5-1.6-62-43.2-109.6-106.8 9.2-7.2 17.5-15.5 24.6-24.6 63.6 47.6 105.2 90.2 106.8 109.6 0 1.4-1.6 6.3-7.2 12.4z'/></svg></button>
 <button id='info'><svg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='8' stroke='#004d80' fill='none'/><path d='M10 5.5c-1.25 0-2.25 1-2.25 2.25H9a1.25 1.25 0 0 1 2.5 0c0 .65-.55 1-1 1.2-.7.35-1.25.85-1.25 1.8V11h1.5v-.25c0-.37.29-.65.68-.83.73-.34 1.32-.87 1.32-2.17 0-1.25-1.5-2.25-2.75-2.25' fill='#ff8d40' stroke='#ff8d40' stroke-width='.6' stroke-linecap='round' stroke-linejoin='round'/><circle cx='10' cy='13.5' r='1.2' fill='#ff8d40'/></svg></button>
+<button id='theme-toggle' title='Toggle dark mode (D)'><svg class='theme-icon-light' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='#004d80' stroke-width='2'/><path d='M10 3a7 7 0 0 1 0 14z' fill='#004d80'/></svg><svg class='theme-icon-dark' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='#ff8d40' stroke-width='2'/><path d='M10 3a7 7 0 0 0 0 14z' fill='#ff8d40'/></svg></button>
 </header>
 <header style='float: right'>Produced by <a href='https://github.com/async-profiler/async-profiler'>async-profiler</a></header>
 <div id='legend' style='position: absolute'>
@@ -63,6 +73,7 @@
 	<dt>Ctrl+F</dt><dd>Search</dd>
 	<dt>N</dt><dd>Next match</dd>
 	<dt>Shift+N</dt><dd>Previous match</dd>
+	<dt>D</dt><dd>Toggle dark mode</dd>
 	<dt>Esc</dt><dd>Cancel search</dd>
 </dl>
 </div>
@@ -74,6 +85,7 @@
 	// Copyright The async-profiler authors
 	// SPDX-License-Identifier: Apache-2.0
 	'use strict';
+
 	let root, px, pattern;
 	let level0 = 0, left0 = 0, width0 = 0, d = 0;
 	let nav = [], navIndex, matchval;
@@ -118,6 +130,10 @@
 		if (diff === 0) return '#e0e0e0';
 		const v = Math.round(128 * (maxdiff - Math.abs(diff)) / maxdiff) + 96;
 		return diff > 0 ? 'rgb(255,' + v + ',' + v + ')' : 'rgb(' + v + ',' + v + ',255)';
+	}
+
+	function cssVar(v) {
+		return getComputedStyle(document.documentElement).getPropertyValue(v);
 	}
 
 	function f(key, level, left, width, inln, c1, int) {
@@ -197,7 +213,7 @@
 
 	function render(newRoot, nav) {
 		if (root) {
-			c.fillStyle = '#ffffff';
+			c.fillStyle = cssVar('--bg-color');
 			c.fillRect(0, 0, canvasWidth, canvasHeight);
 		}
 
@@ -239,7 +255,7 @@
 				}
 
 				if (f.level < root.level) {
-					c.fillStyle = 'rgba(255, 255, 255, 0.5)';
+					c.fillStyle = cssVar('--dim-overlay');
 					c.fillRect((f.left - x0) * px, y, f.width * px, 15);
 				}
 			}
@@ -330,6 +346,15 @@
 		legend.style.display = 'none';
 	}
 
+	document.getElementById('theme-toggle').onclick = function() {
+		const newTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+		document.documentElement.dataset.theme = newTheme;
+		try {
+			localStorage.setItem('color-mode', newTheme);
+		} catch (ignored) {}
+		render(root);
+	}
+
 	window.onkeydown = function(event) {
 		if ((event.ctrlKey || event.metaKey) && event.key === 'f') {
 			event.preventDefault();
@@ -347,6 +372,9 @@
 		} else if (event.key === 'i') {
 			canvas.onmouseout();
 			document.getElementById('inverted').onclick();
+			return false;
+		} else if (event.key === 'd') {
+			document.getElementById('theme-toggle').onclick();
 			return false;
 		} else if (event.key === '0') {
 			canvas.onmouseout();

--- a/src/res/heatmap.html
+++ b/src/res/heatmap.html
@@ -3,10 +3,44 @@
 <head>
 <meta charset='utf-8'>
 <style>
+	:root {
+		--bg-color: #ffffff;
+		--text-color: #000000;
+		--tooltip-bg: #ffffe0;
+		--tooltip-border: #ffc000;
+		--legend-border: #666666;
+		--link-color: #0366d6;
+		--dim-overlay: rgba(255, 255, 255, 0.25);
+		--sidebar-bg: #efefef;
+		--toolbar-selected-bg: #cccccc;
+		--toolbar-selected-border: #999999
+	}
+	[data-theme="dark"] {
+		--bg-color: #1e1e1e;
+		--text-color: #d4d4d4;
+		--tooltip-bg: #2d2d2d;
+		--tooltip-border: #555555;
+		--legend-border: #555555;
+		--link-color: #58a6ff;
+		--dim-overlay: rgba(30, 30, 30, 0.25);
+		--sidebar-bg: #2a2a2a;
+		--toolbar-selected-bg: #444444;
+		--toolbar-selected-border: #666666;
+	}
+	.theme-icon-dark {
+		display: none;
+	}
+	[data-theme="dark"] .theme-icon-light {
+		display: none;
+	}
+	[data-theme="dark"] .theme-icon-dark {
+		display: inline;
+	}
 	body {
 		margin: 0;
 		padding: 4px 8px 24px;
-		background-color: #ffffff;
+		background-color: var(--bg-color);
+		color: var(--text-color);
 		overflow-y: scroll
 	}
 	h1 {
@@ -27,7 +61,7 @@
 		margin: 5px 0 5px 0
 	}
 	a {
-		color: #0366d6
+		color: var(--link-color)
 	}
 	#hl {
 		position: absolute;
@@ -35,15 +69,16 @@
 		overflow: hidden;
 		white-space: nowrap;
 		pointer-events: none;
-		background-color: #ffffe0;
-		outline: 1px solid #ffc000;
+		background-color: var(--tooltip-bg);
+		outline: 1px solid var(--tooltip-border);
+		color: var(--text-color);
 		height: 15px
 	}
 	#preview_wrapper {
 		position: absolute;
 		display: none;
-		background-color: #ffffe0;
-		outline: 1px solid #ffc000;
+		background-color: var(--tooltip-bg);
+		outline: 1px solid var(--tooltip-border);
 		pointer-events: none;
 	}
 	#hl span {
@@ -100,13 +135,14 @@
 		top: 10px;
 		right: 48px;
 		width: 204px;
-		border: 1px solid #666666;
-		background: #ffffe0;
+		border: 1px solid var(--legend-border);
+		background: var(--tooltip-bg);
+		color: var(--text-color);
 		border-radius: 8px;
 		padding: 4px
 	}
 	#heatmap-height-line {
-		text-decoration: #0366d6 dashed underline;
+		text-decoration: var(--link-color) dashed underline;
 		cursor: pointer;
 		font-family: monospace
 	}
@@ -126,17 +162,17 @@
 		align-items: center;
 	}
 	.toolbarSelected {
-		background-color: #cccccc;
-		outline: 1px solid #999999;
+		background-color: var(--toolbar-selected-bg);
+		outline: 1px solid var(--toolbar-selected-border);
 		border-radius: 4px;
 	}
 	.toolbarIcon:hover {
-		background-color: #ffffe0;
-		outline: 1px solid #ffc000;
+		background-color: var(--tooltip-bg);
+		outline: 1px solid var(--tooltip-border);
 		border-radius: 4px;
 	}
 	.bordered {
-		outline: 1px solid #999999;
+		outline: 1px solid var(--toolbar-selected-border);
 	}
 	.colortip {
 		width: 100px;
@@ -148,16 +184,21 @@
 		position: fixed;
 		bottom: 0;
 		padding: 2px 4px;
-		background-color: #ffffe0;
-		border-top: 1px solid #ffc000;
-		border-left: 1px solid #ffc000;
-		border-right: 1px solid #ffc000;
+		background-color: var(--tooltip-bg);
+		border-top: 1px solid var(--tooltip-border);
+		border-left: 1px solid var(--tooltip-border);
+		border-right: 1px solid var(--tooltip-border);
+		color: var(--text-color);
 	}
 </style>
+<script>
+	document.documentElement.dataset.theme = localStorage.getItem('color-mode') ||
+		(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+</script>
 </head>
 <body style='font: 12px Verdana, sans-serif'>
 <div class='bordered' style="display: flex">
-	<div class='bordered' style="width: 20px; margin-right: 1px; padding: 2px; float: left; background-color: #efefef; writing-mode: vertical-rl; transform: scale(-1); text-align: center; user-select: none">
+	<div class='bordered' style="width: 20px; margin-right: 1px; padding: 2px; float: left; background-color: var(--sidebar-bg); writing-mode: vertical-rl; transform: scale(-1); text-align: center; user-select: none">
 		<pre id="heatmap-height-line"> 1 sec : 20 ms </pre>
 	</div>
 
@@ -185,7 +226,7 @@
 		<div id='rightMiddleDiff' class='selectionPart left'><span></span></div>
 	</div>
 
-	<div class='bordered' style="user-select: none; background-color: #efefef; padding: 2px; margin-left: 1px">
+	<div class='bordered' style="user-select: none; background-color: var(--sidebar-bg); padding: 2px; margin-left: 1px">
 		<div id="heatmap-info" class="toolbarIcon"><svg height="20px" width="20px" viewBox="0 0 392.598 392.598"><path style="fill:#FFFFFF;" d="M274.457,148.234c0.194,17.131-5.236,33.358-15.515,46.933c-23.984,32-36.784,68.331-36.784,104.921 v1.164h-51.911c-0.065-37.107-12.929-73.956-37.107-106.537c-12.735-15.386-17.455-32.065-15.321-49.842 c5.624-45.834,39.822-70.917,74.343-74.925C237.026,67.879,274.457,103.693,274.457,148.234z"></path><rect style="fill:#40b2ff;" x="170.311" y="323.038" width="51.846" height="47.774"></rect><path style="fill:#ff8d40;" d="M196.299,91.604c-0.905,0-1.939,0-2.844,0.065c-17.842,0.84-33.681,10.279-43.442,24.178h42.408 c6.012,0,10.925,4.848,10.925,10.925s-4.848,10.925-10.925,10.925h-51.588c-0.453,2.651-0.84,5.301-1.034,8.016 c-0.259,4.719,0.129,9.244,1.099,13.77h25.988c6.012,0,10.925,4.848,10.925,10.925c0,6.012-4.848,10.925-10.925,10.925h-16.356 c0.065,0.129,0.129,0.323,0.323,0.388c22.238,30.061,35.943,63.418,40.016,97.681h10.796c3.943-34.263,17.519-67.556,39.952-97.358 c7.37-9.826,11.313-21.463,11.313-33.875C252.865,117.075,227.523,91.604,196.299,91.604z"></path><path style="fill:#004d80;" d="M196.299,36.137c6.012,0,10.925-4.848,10.925-10.925V10.925C207.224,4.913,202.376,0,196.299,0 c-6.012,0-10.925,4.848-10.925,10.925v14.287C185.374,31.289,190.287,36.137,196.299,36.137z"></path> <path style="fill:#004d80;" d="M333.543,137.309h-14.287c-6.012,0-10.925,4.848-10.925,10.925c0,6.012,4.849,10.925,10.925,10.925 h14.287c6.012,0,10.925-4.848,10.925-10.925S339.556,137.309,333.543,137.309z"></path> <path style="fill:#004d80;" d="M73.277,137.309H59.055c-6.012,0-10.925,4.848-10.925,10.925c0,6.012,4.848,10.925,10.925,10.925 h14.287c6.012,0,10.925-4.848,10.925-10.925C84.202,142.158,79.289,137.309,73.277,137.309z"></path> <path style="fill:#004d80;" d="M285.64,43.507l-10.15,10.149c-4.267,4.267-4.267,11.119,0,15.45c4.267,4.267,11.119,4.267,15.451,0 l10.15-10.149c4.267-4.267,4.267-11.119,0-15.451C296.824,39.176,289.907,39.176,285.64,43.507z"></path> <path style="fill:#004d80;" d="M101.657,227.491l-10.085,10.02c-4.267,4.267-4.267,11.119,0,15.451 c4.267,4.331,11.119,4.267,15.451,0l10.02-10.02c4.267-4.267,4.267-11.119,0-15.451 C112.776,223.224,105.859,223.224,101.657,227.491z"></path> <path style="fill:#004d80;" d="M290.941,227.491c-4.267-4.267-11.119-4.267-15.451,0c-4.267,4.267-4.267,11.119,0,15.451 l10.15,10.149c4.267,4.267,11.119,4.267,15.451,0s4.267-11.119,0-15.451L290.941,227.491z"></path> <path style="fill:#004d80;" d="M101.657,68.978c4.267,4.267,11.119,4.267,15.451,0c4.267-4.267,4.267-11.119,0-15.451l-10.02-10.02 c-4.267-4.267-11.119-4.267-15.451,0c-4.267,4.267-4.267,11.119,0,15.451L101.657,68.978z"></path> <path style="fill:#004d80;" d="M191.257,48.097c-51.2,2.457-92.962,44.606-95.095,95.806c-1.034,23.208,5.818,45.188,19.523,63.741 c21.463,28.962,32.84,61.414,32.84,93.996v80.032c0,6.012,4.848,10.925,10.925,10.925h73.632c6.012,0,10.925-4.848,10.925-10.925 l0.065-81.584c0-31.935,11.184-63.677,32.388-91.798c13.123-17.455,20.04-38.141,20.04-60.057 C296.436,91.345,248.921,45.253,191.257,48.097z M222.093,370.812h-51.846v-47.774h51.846L222.093,370.812L222.093,370.812z M258.941,195.168c-23.984,32-36.784,68.331-36.784,104.921v1.164h-51.911c-0.065-37.107-12.929-73.956-37.107-106.537 c-12.735-15.386-17.455-32.065-15.321-49.842c5.624-45.834,39.822-70.917,74.343-74.925c44.865-2.069,82.295,33.745,82.295,78.287 C274.651,165.366,269.22,181.592,258.941,195.168z"></path></svg></div>
 		<div id="search" class="toolbarIcon" title="Search by Regex [Ctrl + F]"><svg height="20px" width="20px" viewBox="-39.26 -39.26 471.13 471.13" xml:space="preserve" fill="#000000" stroke="#000000" stroke-width="0.00392609"><path style="fill:#FFFFFF;" d="M273.713,147.774c0,69.495-56.501,125.931-125.931,125.931c-69.495,0-125.931-56.501-125.931-125.931 c0-69.495,56.501-125.931,125.931-125.931C217.212,21.843,273.713,78.344,273.713,147.774z"></path><path style="fill:#40b2ff;" d="M370.747,348.695c0,1.422-1.616,6.271-7.176,12.283c-6.206,6.659-12.477,9.762-14.739,9.762h-0.065 c-19.459-1.616-61.996-43.184-109.576-106.796c0-0.065,0-0.065,0-0.129c9.18-7.24,17.455-15.515,24.63-24.63 c0.065,0,0.065,0,0.129,0C327.564,286.699,369.131,329.301,370.747,348.695z"></path><path style="fill:#ff8d40;" d="M208.679,86.877l-14.481,14.481c-17.131,17.131-46.545,5.042-46.545-19.265V61.6 c-49.002,0-88.372,40.792-86.109,90.246c2.004,43.895,38.141,80.032,82.036,82.036c49.455,2.263,90.246-37.172,90.246-86.109 C233.956,124.049,224.323,102.522,208.679,86.877z"></path><path style="fill:#004d80;" d="M276.105,220.954c12.347-21.527,19.459-46.545,19.459-73.18c0-81.455-66.327-147.717-147.846-147.717 S0,66.32,0,147.904s66.327,147.717,147.717,147.717c26.57,0,51.523-7.111,73.18-19.459 c39.822,53.333,91.863,113.519,126.061,116.364c12.283,0.517,22.885-6.723,32.776-16.743c5.172-5.624,13.77-16.937,12.8-28.768 C389.624,312.881,329.438,260.776,276.105,220.954z M147.717,273.77c-69.495,0-125.931-56.501-125.931-125.931 S78.287,21.908,147.717,21.908s125.931,56.501,125.931,125.931S217.212,273.77,147.717,273.77z M363.572,360.978 c-6.206,6.659-12.412,9.762-14.739,9.762h-0.065c-19.459-1.616-61.996-43.184-109.576-106.796c0-0.065,0-0.065,0-0.129 c9.18-7.24,17.455-15.515,24.63-24.63c0.065,0,0.065,0,0.129,0c63.612,47.58,105.18,90.182,106.796,109.576 C370.747,350.118,369.131,354.966,363.572,360.978z"></path></svg></div>
 		<div id="filter" class="toolbarIcon" title="Filter by Regex [Shift + Ctrl + F]"><svg height="16px" width="16px" viewBox="0 0 392.541 392.541"><path style="fill:#FFFFFF;" d="M219.345,344.911V190.988c0-2.909,1.164-5.689,3.232-7.758L367.386,39.586 c3.814-3.814,3.426-7.434,2.392-9.891c-1.487-3.62-6.012-7.887-13.834-7.887H36.137c-7.822,0-12.347,4.267-13.834,7.887 c-1.034,2.392-1.422,6.077,2.392,9.891L169.503,183.23c2.069,2.004,3.232,4.848,3.232,7.758v174.093L219.345,344.911z"></path><path style="fill:#40b2ff;" d="M59.733,43.594L91.41,75.012c0.065,0,0.259,0,0.323,0h97.228c6.012,0,10.925,4.848,10.925,10.925 c0,6.012-4.848,10.925-10.925,10.925h-75.636l22.044,21.786h31.741c6.012,0,10.925,4.848,10.925,10.925 c0,6.012-4.848,10.925-10.925,10.925h-9.826l38.853,38.335l136.21-135.176L59.733,43.594L59.733,43.594z"></path><path style="fill:#004d80;" d="M356.008,0.022H36.137c-30.578,0-47.968,33.487-26.828,55.079l141.705,140.412v186.053 c0.065,7.111,7.564,13.382,15.192,10.02l68.396-29.543c4.008-1.681,6.594-5.624,6.594-10.02V195.513l141.64-140.412 C404.234,33.767,388.008,0.022,356.008,0.022z M367.45,39.586L222.642,183.23c-2.069,2.004-3.232,4.848-3.232,7.758v153.923 l-46.61,20.105V190.988c0-2.909-1.164-5.689-3.232-7.758L24.759,39.586c-8.339-8.792,1.099-18.295,11.442-17.778h319.806 C367.45,21.485,375.337,32.41,367.45,39.586z"></path></svg></div>
@@ -199,6 +240,10 @@
 		</div>
 		<div id="flame-mode-methods" class="toolbarIcon" title="Methods List [Ctrl + 3]">
 			<svg height="20px" width="20px" viewBox="0 0 20 20"><rect x="0" y="0" style="fill:#ff8d40;" width="20" height="4"></rect><rect x="0" y="5" style="fill:#40b2ff;" width="16" height="4"></rect><rect x="0" y="10" style="fill:#ff8d40;" width="8" height="4"></rect><rect x="0" y="15" style="fill:#40b2ff;" width="4" height="4"></rect></svg>
+		</div>
+		<div id="theme-toggle" class="toolbarIcon" style="margin-top: 16px" title="Toggle dark mode [D]">
+			<svg class='theme-icon-light' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='#004d80' stroke-width='2'/><path d='M10 3a7 7 0 0 1 0 14z' fill='#004d80'/></svg>
+			<svg class='theme-icon-dark' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='#ff8d40' stroke-width='2'/><path d='M10 3a7 7 0 0 0 0 14z' fill='#ff8d40'/></svg>
 		</div>
 
 		<div id="info-tooltip">
@@ -220,7 +265,7 @@
 				<div class="colortip" style="--c1:#42ff8e;--c2:#ccffe0">Less frames</div>
 				<div class="colortip" style="--c1:#ff8d40;--c2:#ffe0cc">More frames</div>
 			</div>
-			<div style="float:left; margin-top: 4px; width: 100%; border: 1px solid #666666; border-radius: 2px; padding: 2px; box-sizing: border-box;">
+			<div style="float:left; margin-top: 4px; width: 100%; border: 1px solid var(--legend-border); border-radius: 2px; padding: 2px; box-sizing: border-box;">
 				Shift + Click - Select range<br>
 				Ctrl + Click - Compare<br>
 				<br>
@@ -255,6 +300,10 @@
 	// Copyright The async-profiler authors
 	// SPDX-License-Identifier: Apache-2.0
 	'use strict';
+
+	function cssVar(v) {
+		return getComputedStyle(document.documentElement).getPropertyValue(v);
+	}
 
 	let dR, dG, dB;
 	let dRs, dGs, dBs;
@@ -349,6 +398,16 @@
 
 	document.getElementById('filter').onclick = () => {
 		search(true, true);
+	};
+
+	document.getElementById('theme-toggle').onclick = function() {
+		const newTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+		document.documentElement.dataset.theme = newTheme;
+		try {
+			localStorage.setItem('color-mode', newTheme);
+		} catch (ignored) {}
+		if (root) render(root, rootLevel);
+		if (heatC) redrawHeatMap();
 	};
 
 	const palette = [
@@ -460,7 +519,7 @@
 	function render(newRoot, newLevel, minLevel) {
 		minLevel = minLevel || 0;
 		if (root && minLevel === 0) {
-			c.fillStyle = '#ffffff';
+			c.fillStyle = cssVar('--bg-color');
 			c.fillRect(0, 0, canvasWidth, canvasHeight);
 		}
 
@@ -510,7 +569,7 @@
 				}
 
 				if (alpha) {
-					c.fillStyle = 'rgba(255, 255, 255, 0.25)';
+					c.fillStyle = cssVar('--dim-overlay');
 					c.fillRect((f.left - x0) * px, y, fw, 15);
 				}
 			}
@@ -555,7 +614,7 @@
 		const c = preview.getContext('2d');
 		if (devicePixelRatio) c.scale(devicePixelRatio, devicePixelRatio);
 		c.font = document.body.style.font;
-		c.fillStyle = '#ffffff';
+		c.fillStyle = cssVar('--bg-color');
 		c.fillRect(0, 0, w, h);
 		for (let i = 0; i < 15; i++) {
 			const level = Math.floor(previewY / 16) + i - 7;
@@ -1295,7 +1354,7 @@
 	function prepareRender() {
 		root = undefined;
 		rootLevel = 0;
-		c.fillStyle = '#ffffff';
+		c.fillStyle = cssVar('--bg-color');
 		c.fillRect(0, 0, canvasWidth, canvasHeight);
 		hl.style.display = 'none';
 		addTask('flame', function () {
@@ -4203,6 +4262,9 @@
 				break;
 			case 'Escape':
 				search(false);
+				break;
+			case 'd':
+				document.getElementById('theme-toggle').onclick();
 				break;
 			default:
 				return;

--- a/src/res/tree.html
+++ b/src/res/tree.html
@@ -4,6 +4,41 @@
     <title>Tree view</title>
     <meta charset="utf-8" />
     <style>
+      :root {
+        --bg-color: #ffffff;
+        --text-color: #000000;
+        --secondary-text: #5e5e5e;
+        --toolbar-bg: #f5f5f5;
+        --input-bg: #ffffff;
+        --input-border: rgba(32, 35, 40, 0.1);
+        --border-color: #e9e9e9;
+        --tree-line-color: #252527;
+        --highlight-bg: #d9d9d9;
+        --child-count-border: #abb1c1;
+        --child-count-color: #7d8089;
+      }
+      [data-theme="dark"] {
+        --bg-color: #1e1e1e;
+        --text-color: #d4d4d4;
+        --secondary-text: #999999;
+        --toolbar-bg: #2a2a2a;
+        --input-bg: #333333;
+        --input-border: #555555;
+        --border-color: #3c3c3c;
+        --tree-line-color: #999999;
+        --highlight-bg: #404040;
+        --child-count-border: #555555;
+        --child-count-color: #999999;
+      }
+      .theme-icon-dark {
+        display: none;
+      }
+      [data-theme="dark"] .theme-icon-light {
+        display: none;
+      }
+      [data-theme="dark"] .theme-icon-dark {
+        display: inline;
+      }
       html,
       body,
       div,
@@ -21,7 +56,8 @@
       body {
         line-height: 140%;
         font-family: Arial;
-        background: white;
+        background: var(--bg-color);
+        color: var(--text-color);
         font-size: 15px;
       }
       ul {
@@ -50,7 +86,7 @@
         top: 0;
         bottom: 0;
         margin: auto;
-        background: #252527;
+        background: var(--tree-line-color);
       }
       .tree li div:before {
         width: 10px;
@@ -74,7 +110,7 @@
         position: relative;
         display: inline;
         cursor: pointer;
-        color: black;
+        color: var(--text-color);
         text-decoration: none;
       }
       .tree li > div:first-word {
@@ -86,17 +122,18 @@
         display: none !important;
       }
       .sc {
-        text-decoration-color: black;
+        text-decoration-color: var(--text-color);
         font-weight: bold;
-        background-color: #d9d9d9;
+        background-color: var(--highlight-bg);
       }
       input {
         height: 36px;
         padding: 0 14px;
         border-radius: 4px;
-        background: white;
+        background: var(--input-bg);
+        color: var(--text-color);
         font-size: 16px;
-        border: 1px solid #2023281a;
+        border: 1px solid var(--input-border);
       }
       button {
         height: 36px;
@@ -110,17 +147,17 @@
         color: #00ac4f;
       }
       .button_outlined {
-        color: black;
+        color: var(--text-color);
         font-size: 15px;
         padding: 0 12px;
-        background: white;
-        border: 1px solid #2023281a;
+        background: var(--input-bg);
+        border: 1px solid var(--input-border);
         display: flex;
         align-items: center;
         gap: 8px;
       }
       .total-count {
-        color: #5e5e5e;
+        color: var(--secondary-text);
         font-weight: bold;
         font-size: 14px;
       }
@@ -136,7 +173,7 @@
         flex-direction: row;
         z-index: 100;
         padding: 8px 20px;
-        background: #f5f5f5;
+        background: var(--toolbar-bg);
         align-items: center;
         box-sizing: border-box;
         width: 100%;
@@ -181,15 +218,15 @@
       }
       .wrapper {
         padding: 70px 20px 10px;
-        background: white;
-        border-top: 1px solid #e9e9e9;
+        background: var(--bg-color);
+        border-top: 1px solid var(--border-color);
       }
 
       .child-count {
-        border: 1px solid #abb1c1;
+        border: 1px solid var(--child-count-border);
         border-radius: 3px;
         padding: 0 5px;
-        color: #7d8089;
+        color: var(--child-count-color);
       }
 
       .t0,
@@ -215,6 +252,16 @@
       }
     </style>
 <script>
+document.documentElement.dataset.theme = localStorage.getItem('color-mode') ||
+	(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+
+function toggleTheme() {
+	var newTheme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark';
+	document.documentElement.dataset.theme = newTheme;
+	try {
+		localStorage.setItem('color-mode', newTheme);
+	} catch (ignored) {}
+}
 function treeView(opt) {
 	var tree = document.querySelectorAll('ul.tree div:not(:last-child)');
 	for(var i = 0; i < tree.length; i++){
@@ -311,6 +358,9 @@ for(var i = 0; i < tree.length; i++){
         </div>
         <div class="header-item header-item_search">
           <input class="search-input" type="text" id="search" value="" placeholder="Search..." size="35" onkeypress="if(event.keyCode == 13) search()"/>
+        </div>
+        <div class="header-item">
+          <button type="button" onclick="toggleTheme()" class="button_outlined" id="theme-toggle" title="Toggle dark mode"><svg class='theme-icon-light' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='currentColor' stroke-width='2'/><path d='M10 3a7 7 0 0 1 0 14z' fill='currentColor'/></svg><svg class='theme-icon-dark' xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 20 20'><circle cx='10' cy='10' r='7' fill='none' stroke='currentColor' stroke-width='2'/><path d='M10 3a7 7 0 0 0 0 14z' fill='currentColor'/></svg></button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Description

Adds a light/dark mode toggle to the existing toolbar of the generated HTML flame graph, heatmap and tree view. On first load the initial mode is obtained from the browser's `prefers-color-scheme` property, and if the user changes it using the toggle, the preference is persisted in local storage under the key `color-mode`. Falls back to light mode if neither is available.

### Related issues

Closes [#1720 ](https://github.com/async-profiler/async-profiler/issues/1720)

### Motivation and context

the generated html has a fixed white background, which makes it pretty painful to use in dark mode setups (or in dark environments), especially during long profiling sessions where the file stays open for a while

As context and scope: the scope is intentionally limited to UI with no semantic meaning: body/canvas background, text colors (title, details bar, search box, tooltips) and toolbar styling. 
Frame colors like green=Java, yellow=JVM/C++, red=kernel, etc. stay completely untouched... they're semantically meaningful and a full alternative palette would be a separate discussion. This PR does not add new color scheme palettes.

### How has this been tested?

results were verified in Chrome, Firefox and Safari, it works as expected in all of them.

<img width="797" height="563" alt="imagen" src="https://github.com/user-attachments/assets/efb9d4e8-cc0d-47a0-ab76-06ad3f1fc689" />

<img width="786" height="597" alt="imagen" src="https://github.com/user-attachments/assets/1193ba27-f21f-4699-a6af-d252e56583f2" />


---

color-mode was checked in all localStorages as well, working as expected (including fallback):
<img width="768" height="310" alt="imagen" src="https://github.com/user-attachments/assets/0b77bbb9-74b0-4c36-8aae-8517660f11ac" />

<img width="482" height="297" alt="imagen" src="https://github.com/user-attachments/assets/b7860d84-f040-42d0-bfeb-77e514a5d9be" />

---

It was also tested that frames in flame or other elements were not affected

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
