### PR TITLE
Size comparison

### DIFF
--- a/.github/workflows/compare-binary-sizes.yaml
+++ b/.github/workflows/compare-binary-sizes.yaml
@@ -1,0 +1,28 @@
+name: compare-binary-sizes
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+env:
+  GH_TOKEN: "${{ github.token }}"
+  REPO: "${{ github.repository }}"
+  PR_SHA: "${{ github.event.workflow_run.head_sha }}"
+jobs:
+  compare:
+    if: ${{ github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          gh api "repos/${REPO}/contents/scripts/compare-binary-sizes.sh" -H 'Accept: application/vnd.github.raw' > compare.sh
+          read pr base_sha < <(gh api "repos/${REPO}/commits/${PR_SHA}/pulls" --jq '.[0] | "\(.number) \(.base.sha)"')
+          function find-archive() { find "${1}" -type f \( -name "async-profiler-*${2}.tar.gz" -o -name "async-profiler-*${2}.zip" \) ! -name '*-debug*' | head -n1; }
+          for p in linux-x64 linux-arm64 macos; do
+            gh run download -R "${REPO}" -n "async-profiler-${p}-${base_sha:0:7}" -D "base/${p}" 2>/dev/null || continue
+            gh run download -R "${REPO}" -n "async-profiler-${p}-${PR_SHA:0:7}"   -D "pr/${p}"   2>/dev/null || continue
+            bash compare.sh "$(find-archive "base/${p}" "${p}")" "$(find-archive "pr/${p}" "${p}")" >> report.md
+          done
+          gh pr comment "${pr}" -R "${REPO}" --body-file report.md --edit-last --create-if-none

--- a/scripts/compare-binary-sizes.sh
+++ b/scripts/compare-binary-sizes.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Copyright The async-profiler authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+function list-archive() {
+    case "${1}" in
+        *.tar.gz) tar -tzvf "${1}" --wildcards '*/bin/*' '*/lib/*' | awk '$1 ~ /^-/ { print $NF, $3 }' ;;
+        *.zip)    zipinfo -l "${1}"           '*/bin/*' '*/lib/*'  | awk '$1 ~ /^-/ { print $NF, $4 }' ;;
+    esac | cut -d/ -f2- | sort
+}
+
+function main() {
+    if [[ ${#} -ne 2 ]]; then
+        printf 'Usage: compare-binary-sizes.sh <base-archive> <treatment-archive>\n' >&2
+        exit 1
+    fi
+
+    [[ ${1} =~ (linux-x64|linux-arm64|macos) ]]
+    printf '### %s\n\n| File | Base (KiB) | Treatment (KiB) | Delta (KiB) | %% Change |\n| --- | ---: | ---: | ---: | ---: |\n' "${BASH_REMATCH[1]}"
+    join -a1 -a2 -e0 -o '0,1.2,2.2' \
+         <(list-archive "${1}") \
+         <(list-archive "${2}") \
+        | awk '{
+            b = $2; t = $3; d = t - b; pct = b > 0 ? d * 100 / b : 0
+            printf "| `%s` | %.2f | %.2f | %+.2f | %+.2f%% |\n", $1, b/1024, t/1024, d/1024, pct
+        }'
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"


### PR DESCRIPTION
### Description
Adds script and workflows to post a comment to pull requests with the size comparison for Linux and macos binaries included

### How has this been tested?

Ran the workflow on a test branch in my fork: https://github.com/benty-amzn/async-profiler/actions/runs/25021267551/job/73282029524

The table is reproduced here for convenience:

### linux-x64

| File | Base (KiB) | Treatment (KiB) | Delta (KiB) | % Change |
| --- | ---: | ---: | ---: | ---: |
| `bin/asprof` | 81.72 | 81.72 | +0.00 | +0.00% |
| `bin/jfrconv` | 133.73 | 133.73 | +0.00 | +0.00% |
| `lib/libasyncProfiler.so` | 590.01 | 590.01 | +0.00 | +0.00% |
### linux-arm64

| File | Base (KiB) | Treatment (KiB) | Delta (KiB) | % Change |
| --- | ---: | ---: | ---: | ---: |
| `bin/asprof` | 89.59 | 89.59 | +0.00 | +0.00% |
| `bin/jfrconv` | 133.73 | 133.73 | +0.00 | +0.00% |
| `lib/libasyncProfiler.so` | 609.29 | 609.29 | +0.00 | +0.00% |
### macos

| File | Base (KiB) | Treatment (KiB) | Delta (KiB) | % Change |
| --- | ---: | ---: | ---: | ---: |
| `bin/asprof` | 116.74 | 116.74 | +0.00 | +0.00% |
| `bin/jfrconv` | 133.73 | 133.73 | +0.00 | +0.00% |
| `lib/libasyncProfiler.dylib` | 991.34 | 991.34 | +0.00 | +0.00% |

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
