### PR TITLE
Retry vDSO unwinding on AArch64 using the default frame

### DIFF
--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -430,6 +430,7 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
 
         FrameDesc* f = native_lib != NULL ? native_lib->findFrameDesc(pc) : &FrameDesc::default_frame;
 
+        retry_unwind_frame:
         u8 cfa_reg = (u8)f->cfa;
         int cfa_off = f->cfa >> 8;
         if (cfa_reg == DW_REG_SP) {
@@ -456,7 +457,6 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
-            retry_unwind_frame:
             if (f->fp_off != DW_SAME_FP && f->fp_off < MAX_FRAME_SIZE && f->fp_off > -MAX_FRAME_SIZE) {
                 fp = *(uintptr_t*)(sp + f->fp_off);
             }
@@ -465,8 +465,8 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
                 pc = stripPointer(*(void**)(sp + f->pc_off));
             } else if (depth > 1 || (pc = (const void*)frame.link()) == prev_pc) {
                 // Failed to unwind using link register
-                if (f->cfa == DW_REG_SP && f->fp_off == DW_SAME_FP) {
-                    // Special case for vDSO: if an empty frame did not work, retry using the default frame
+                if (f->cfa == DW_REG_SP && fp == sp) {
+                    // Special case for vDSO: if an empty frame did not work, try the default frame
                     f = &FrameDesc::default_frame;
                     goto retry_unwind_frame;
                 }

--- a/src/stackWalker.cpp
+++ b/src/stackWalker.cpp
@@ -456,15 +456,20 @@ int StackWalker::walkVM(void* ucontext, ASGCT_CallFrame* frames, int max_depth, 
         if (f->fp_off & DW_PC_OFFSET) {
             pc = (const char*)pc + (f->fp_off >> 1);
         } else {
+            retry_unwind_frame:
             if (f->fp_off != DW_SAME_FP && f->fp_off < MAX_FRAME_SIZE && f->fp_off > -MAX_FRAME_SIZE) {
                 fp = *(uintptr_t*)(sp + f->fp_off);
             }
 
             if (EMPTY_FRAME_SIZE > 0 || f->pc_off != DW_LINK_REGISTER) {
                 pc = stripPointer(*(void**)(sp + f->pc_off));
-            } else if (depth == 1) {
-                pc = (const void*)frame.link();
-            } else {
+            } else if (depth > 1 || (pc = (const void*)frame.link()) == prev_pc) {
+                // Failed to unwind using link register
+                if (f->cfa == DW_REG_SP && f->fp_off == DW_SAME_FP) {
+                    // Special case for vDSO: if an empty frame did not work, retry using the default frame
+                    f = &FrameDesc::default_frame;
+                    goto retry_unwind_frame;
+                }
                 break;
             }
 

--- a/test/test/recovery/RecoveryTests.java
+++ b/test/test/recovery/RecoveryTests.java
@@ -63,8 +63,7 @@ public class RecoveryTests {
     }
 
     // Verify that System.currentTimeMillis() intrinsic is unwound correctly
-    // TODO: Enable test on JDK 11 after fixing #1653
-    @Test(mainClass = TimeLoop.class, jvm = Jvm.HOTSPOT, jvmVer = {17, Integer.MAX_VALUE}, debugNonSafepoints = true)
+    @Test(mainClass = TimeLoop.class, jvm = Jvm.HOTSPOT, jvmVer = {11, Integer.MAX_VALUE}, debugNonSafepoints = true)
     public void currentTimeMillis(TestProcess p) throws Exception {
         Output out = p.profile("-d 3 -e cpu -o collapsed");
         Assert.isLess(out.ratio("^\\[unknown"), 0.01, "No more than 1% of unknown frames");


### PR DESCRIPTION
### Description

Refactoring of the idea suggested in #1708 by @Baraa-Hasheesh.
See the linked discussion. 

### Related issues

Resolves #1653 

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
