### PR TITLE
dumpOtlp() should accept Counter argument

### DIFF
--- a/src/api/one/profiler/AsyncProfiler.java
+++ b/src/api/one/profiler/AsyncProfiler.java
@@ -201,7 +201,7 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
     @Override
     public String dumpCollapsed(Counter counter) {
         try {
-            return execute0("collapsed," + counter.name().toLowerCase());
+            return execute0("collapsed," + (counter == Counter.SAMPLES ? "samples" : "total"));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -242,12 +242,13 @@ public class AsyncProfiler implements AsyncProfilerMXBean {
      * <p>
      * This API is UNSTABLE and might change or be removed in the next version of async-profiler.
      *
+     * @param counter Which counter to use for aggregation
      * @return OTLP representation of the profile
      */
     @Override
-    public byte[] dumpOtlp() {
+    public byte[] dumpOtlp(Counter counter) {
         try {
-            return execute1("otlp");
+            return execute1("otlp," + (counter == Counter.SAMPLES ? "samples" : "total"));
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/src/api/one/profiler/AsyncProfilerMXBean.java
+++ b/src/api/one/profiler/AsyncProfilerMXBean.java
@@ -31,5 +31,5 @@ public interface AsyncProfilerMXBean {
     String dumpCollapsed(Counter counter);
     String dumpTraces(int maxTraces);
     String dumpFlat(int maxMethods);
-    byte[] dumpOtlp();
+    byte[] dumpOtlp(Counter counter);
 }

--- a/test/test/api/DumpOtlp.java
+++ b/test/test/api/DumpOtlp.java
@@ -5,7 +5,6 @@
 
 package test.api;
 
-import java.nio.ByteBuffer;
 import one.profiler.AsyncProfiler;
 import one.profiler.Counter;
 import one.profiler.Events;
@@ -22,7 +21,7 @@ public class DumpOtlp extends BusyLoops {
         }
 
         // TODO: Should we test this further?
-        byte[] profile = AsyncProfiler.getInstance().dumpOtlp();
+        byte[] profile = AsyncProfiler.getInstance().dumpOtlp(Counter.TOTAL);
         System.out.println(profile.length);
     }
 }

--- a/test/test/otlp/OtlpProfileTimeTest.java
+++ b/test/test/otlp/OtlpProfileTimeTest.java
@@ -5,6 +5,7 @@
 package test.otlp;
 
 import one.profiler.AsyncProfiler;
+import one.profiler.Counter;
 import one.profiler.Events;
 import io.opentelemetry.proto.profiles.v1development.*;
 
@@ -39,7 +40,7 @@ public class OtlpProfileTimeTest {
     }
 
     public static Profile dumpAndGetProfile(AsyncProfiler profiler) throws Exception {
-        byte[] dump = profiler.dumpOtlp();
+        byte[] dump = profiler.dumpOtlp(Counter.SAMPLES);
         ProfilesData data = ProfilesData.parseFrom(dump);
         return data.getResourceProfiles(0).getScopeProfiles(0).getProfiles(0);
     }


### PR DESCRIPTION
### Description

`AsyncProfiler.dumpOtlp()` method now accepts `Counter` argument similarly to `dumpCollapsed()`.

Even though this is a breaking change, I've chosen not to maintain backward compatibility, because this API is quite new and not actively used in the wild. Moreover, it is explicitly [documented](https://github.com/async-profiler/async-profiler/blob/8aab346c3b95e41bace43d5a6811f92309769fb0/src/api/one/profiler/AsyncProfiler.java#L243) as UNSTABLE.

### Related issues

#1624

### Motivation and context

OTLP 1.9.0 significantly changes the structure of the Profile messages, see #1624.
In particular, it is no longer possible to encode the number of samples and the counter (e.g. allocated bytes) at the same time. More precisely, it is possible only if all data is [copied twice](https://github.com/async-profiler/async-profiler/pull/1624#discussion_r2632225001). 

To avoid doubling the size of the profile unconditionally, we instead provide an API to dump a profile with samples only or with a counter only. This already worked in CLI, but the corresponding change in the API was missing.

### How has this been tested?

Updated relevant OTLP tests.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
