### PR TITLE
Support users setting output options for collapsed & flamegraph in the start command

### DIFF
--- a/src/flightRecorder.cpp
+++ b/src/flightRecorder.cpp
@@ -34,7 +34,7 @@
 INCLUDE_HELPER_CLASS(JFR_SYNC_NAME, JFR_SYNC_CLASS, "one/profiler/JfrSync")
 
 static void JNICALL JfrSync_stopProfiler(JNIEnv* env, jclass cls) {
-    Profiler::instance()->stop();
+    Profiler::instance()->expire(_global_args, false);
 }
 
 

--- a/src/javaApi.cpp
+++ b/src/javaApi.cpp
@@ -47,7 +47,7 @@ Java_one_profiler_AsyncProfiler_start0(JNIEnv* env, jobject unused, jstring even
 
 extern "C" DLLEXPORT void JNICALL
 Java_one_profiler_AsyncProfiler_stop0(JNIEnv* env, jobject unused) {
-    Error error = Profiler::instance()->stop();
+    Error error = Profiler::instance()->expire(_global_args, false);
 
     if (error) {
         throwNew(env, "java/lang/IllegalStateException", error.message());

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1541,17 +1541,19 @@ Error Profiler::runInternal(Arguments& args, Writer& out) {
             break;
         }
         case ACTION_STOP: {
-            Error error = stop();
-            if (args._output == OUTPUT_NONE) {
-                if (error) {
-                    return error;
+            MutexLocker ml(_state_lock);
+
+            if (_state == RUNNING) {
+                if (args._output == OUTPUT_NONE) {
+                    if (!(args._quiet || _global_args._quiet) && _global_args._output == OUTPUT_NONE) {
+                        out << "Profiling stopped after " << uptime() << " seconds. No dump options specified.\n";
+                    }
+                    return expire(_global_args, false);
+                } else {
+                    return expire(args, false);
                 }
-                if (!args._quiet) {
-                    out << "Profiling stopped after " << uptime() << " seconds. No dump options specified\n";
-                }
-                break;
             }
-            // Fall through
+            // fall through (backward compatibility for using stop as a dump command)
         }
         case ACTION_DUMP: {
             Error error = dump(out, args);

--- a/src/vmEntry.cpp
+++ b/src/vmEntry.cpp
@@ -538,6 +538,6 @@ extern "C" DLLEXPORT void JNICALL
 JNI_OnUnload(JavaVM* vm, void* reserved) {
     Profiler* profiler = Profiler::instance();
     if (profiler != NULL) {
-        profiler->stop();
+        profiler->expire(_global_args, false);
     }
 }

--- a/test/test/api/ApiTests.java
+++ b/test/test/api/ApiTests.java
@@ -53,4 +53,15 @@ public class ApiTests {
         assert profile.contains("BusyLoops.method2;");
         assert profile.contains("BusyLoops.method3;");
     }
+
+    @Test(mainClass = OutputAtStart.class, args = "%profile.collapsed")
+    public void outputAtStart(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+
+        Output profile = p.readFile("%profile");
+        assert profile.contains("BusyLoops.method1;");
+        assert profile.contains("BusyLoops.method2;");
+        assert profile.contains("BusyLoops.method3;");
+    }
 }

--- a/test/test/api/ApiTests.java
+++ b/test/test/api/ApiTests.java
@@ -60,8 +60,6 @@ public class ApiTests {
         assert p.exitCode() == 0;
 
         Output profile = p.readFile("%profile");
-        assert profile.contains("BusyLoops.method1;");
-        assert profile.contains("BusyLoops.method2;");
-        assert profile.contains("BusyLoops.method3;");
+        assert profile.contains("BusyLoop");
     }
 }

--- a/test/test/api/OutputAtStart.java
+++ b/test/test/api/OutputAtStart.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.api;
+
+import one.profiler.AsyncProfiler;
+
+import java.io.IOException;
+
+public class OutputAtStart {
+
+    public static void main(String[] args) throws IOException {
+        if (args.length < 1) {
+            throw new IllegalArgumentException("Expecting at least one argument for output file");
+        }
+
+        AsyncProfiler instance = AsyncProfiler.getInstance();
+        instance.execute("start,event=cpu,file=" + args[0]);
+
+        BusyLoops.method1();
+        BusyLoops.method2();
+        BusyLoops.method3();
+
+        instance.execute("stop");
+    }
+}


### PR DESCRIPTION
### Description
This change has two main goals:
* Enhance user experience when using async-profiler 
* Make the profiler behaviour more consistent for a given command 

**UX:** Currently certain flags are required at `stop` command to properly dump the output(collapsed & flamegraph) like `file` & `total`, this isn't that intuitive for the user 

With the new change the user can now fully front load everything in the `start` command for example `start,alloc,total,norm,file=output.html` & when wanting to stop the profiler, the user can simply call `stop` without the need to add additional flags here

**Consistency:** Currently if a user launches the profiler with the following command `start,alloc,file=output.collapsed`, the behaviour will be inconsistent depending on how the profiler is stopped for example:
- Profiler stopped via process death => File is dumped
- Profiler stopped via JfrRecording when using jfrsync => file is not dumped
- Profiler stopped via `stop` => file is not dumped

With this new change in all 3 cases the output file is dumped 

Note: This techincally solves a bug where the profiler won't dump the output in agent mode if the profiler was unintentionally stopped via JfrRecording (JfrSync_stopProfiler was called)

Note2: To avoid making the logic more complex than need be I decided on the following, only dump output specified in start command if & only if no output is given in the stop command, otherwise behaviour will default to previous behaviour of dumping output specified in stop command 

### Related issues
N/A

### Motivation and context
Make profiler behaviour more consistent & enhance UX by allowing front loading of dump options in start command 

### How has this been tested?
New test was added

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
