### PR TITLE
Normalize Makefile on 7 char short hashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 *.iml
 /src/api/**/*.class
 .gdb_history
+async-profiler-*.tar.gz
+async-profiler-*.zip
+

--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@
 .gdb_history
 async-profiler-*.tar.gz
 async-profiler-*.zip
-

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROFILER_VERSION ?= 4.4
 
 ifeq ($(COMMIT_TAG),true)
-  PROFILER_VERSION := $(PROFILER_VERSION)-$(shell git rev-parse --short=8 HEAD)
+  PROFILER_VERSION := $(PROFILER_VERSION)-$(shell git rev-parse --short=7 HEAD)
 else ifneq ($(COMMIT_TAG),)
   PROFILER_VERSION := $(PROFILER_VERSION)-$(COMMIT_TAG)
 endif


### PR DESCRIPTION
### Description
This keeps filenames consistent with the workflows in `build.yml` when running `make COMMIT_TAG=true release`

Also add release archives in the project root dir to .gitignore


### Related issues
N/A

### Motivation and context
Housekeeping

### How has this been tested?
`make clean && make COMMIT_TAG=true release` locally produced `async-profiler-4.4-0313038-linux-arm64.tar.gz`, after which `git status` did not show the new archive. This verifies the 7-char hashes and the gitignore change.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
