### PR TITLE
Move otlp proto jar updates into a script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,25 +296,6 @@ build/$(TEST_JAR): build/$(API_JAR) $(TEST_SOURCES) build/$(CONVERTER_JAR) $(TES
 		 $(TEST_SOURCES)
 	$(JAR) cf $@ -C build/test/classes .
 
-update-otlp-classes-jar:
-	@if [ -z "$(OTEL_PROTO_PATH)" ]; then \
-		echo "'OTEL_PROTO_PATH' is empty"; \
-		exit 1; \
-	fi
-	rm -rf $(TMP_DIR)/gen/java $(TMP_DIR)/build
-	mkdir -p $(TMP_DIR)/gen/java $(TMP_DIR)/build $(TEST_GEN_DIR)
-	cd $(OTEL_PROTO_PATH) && protoc --java_out=$(TMP_DIR)/gen/java $$(find . \
-		 -type f \
-		 -name '*.proto' \
-		 -not \( -name 'logs*.proto' -o -name 'metrics*.proto' -o -name 'trace*.proto' -o -name '*service.proto' \))
-	$(JAVAC) -source $(JAVA_TARGET) \
-		 -target $(JAVA_TARGET) \
-		 -cp $(TEST_DEPS_DIR)/* \
-		 -d $(TMP_DIR)/build \
-		 -Xlint:-options \
-		 $$(find $(TMP_DIR)/gen/java -name "*.java")
-	$(JAR) cvf $(TEST_GEN_DIR)/opentelemetry-gen-classes.jar -C $(TMP_DIR)/build .
-
 LINT_SOURCES=`ls -1 src/*.cpp src/*/*.cpp | grep -v rustDemangle.cpp`
 CLANG_TIDY_ARGS_EXTRA=
 cpp-lint:

--- a/scripts/update-otlp-classes.sh
+++ b/scripts/update-otlp-classes.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copyright The async-profiler authors
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+function main() {
+  local java_target otel_version pb_tag pb_java_version tmp_dir
+  otel_version=$(gh api repos/open-telemetry/opentelemetry-proto/releases/latest --jq .tag_name)
+  pb_tag=$(gh release view --repo protocolbuffers/protobuf --json tagName --jq .tagName)
+  pb_java_version="4.${pb_tag#v}"
+  tmp_dir="$(mktemp -d)"
+  java_target="$(grep '^JAVA_TARGET=' Makefile | cut -d= -f2)"
+  mkdir -p test/deps
+  mkdir -p "${tmp_dir}"/gen/java "${tmp_dir}"/build test/gen
+  curl -fL -o "test/deps/protobuf-java-${pb_java_version}.jar" \
+      "https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/${pb_java_version}/protobuf-java-${pb_java_version}.jar"
+  git -c advice.detachedHead=false clone --depth 1 --branch "${otel_version}" https://github.com/open-telemetry/opentelemetry-proto.git "${tmp_dir}/otel"
+  (
+    cd "${tmp_dir}/otel"
+    # protoc will break if the results of this `find` are not split
+    # shellcheck disable=SC2046
+    protoc --java_out="${tmp_dir}"/gen/java \
+      $(find . -type f -name '*.proto' -not \( -name 'logs*.proto' -o -name 'metrics*.proto' -o -name 'trace*.proto' -o -name '*service.proto' \))
+  )
+  # javac will break if the results of this `find` are not split
+  # shellcheck disable=SC2046
+  javac -source "${java_target}" -target "${java_target}" -Xlint:-options -cp test/deps/* -d "${tmp_dir}"/build $(find "${tmp_dir}"/gen/java -name '*.java')
+  jar cf test/gen/opentelemetry-gen-classes.jar -C "${tmp_dir}"/build .
+  rm -rf "${tmp_dir}"
+}
+
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && main "$@"


### PR DESCRIPTION
### Description
Move otlp updates into a script since they're not part of a normal build and don't belong in the Makefile

### Related issues


### Motivation and context


### How has this been tested?

Ran the script locally; passed and afterwards `git status` shows `modified:   test/gen/opentelemetry-gen-classes.jar`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
