### PR TITLE
Update builds to reduce overall binary size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 CFLAGS_EXTRA ?=
 CXXFLAGS_EXTRA ?=
 CFLAGS=-O3 -fno-exceptions $(CFLAGS_EXTRA)
-CXXFLAGS=-O3 -fno-exceptions -fno-omit-frame-pointer -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
+CXXFLAGS=-O3 -fno-exceptions -fno-rtti -fno-omit-frame-pointer -fvisibility=hidden -std=c++11 $(CXXFLAGS_EXTRA)
 CPPFLAGS=
 DEFS=-DPROFILER_VERSION=\"$(PROFILER_VERSION)\"
 INCLUDES=-I$(JAVA_HOME)/include -Isrc/helper


### PR DESCRIPTION
### Description
Update build arguments to include `-fno-rtti`

### Related issues


### Motivation and context
Relatively simple change with a clear ~2% win in overall binary size in local testing

### How has this been tested?
Ran the Docker build and binary size comparison scripts locally; build passed and script indicated a -8KiB change in `lib/libasyncProfiler.so`

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
