### PR TITLE
Add support for HotCodeHeap

### DIFF
--- a/src/vmStructs.cpp
+++ b/src/vmStructs.cpp
@@ -83,7 +83,7 @@ int VMStructs::_flag_origin_offset = -1;
 const char* VMStructs::_flags_addr = NULL;
 int VMStructs::_flag_count = 0;
 int VMStructs::_flag_size = 0;
-char* VMStructs::_code_heap[3] = {};
+char* VMStructs::_code_heap[4] = {};
 const void* VMStructs::_code_heap_low = NO_MIN_ADDRESS;
 const void* VMStructs::_code_heap_high = NO_MAX_ADDRESS;
 char** VMStructs::_code_heap_addr = NULL;
@@ -534,7 +534,7 @@ void VMStructs::resolveOffsets() {
     if (_code_heap_addr != NULL && _code_heap_low_addr != NULL && _code_heap_high_addr != NULL) {
         char* code_heaps = *_code_heap_addr;
         unsigned int code_heap_count = *(unsigned int*)(code_heaps + _array_len_offset);
-        if (code_heap_count <= 3 && _array_data_offset >= 0) {
+        if (code_heap_count <= 4 && _array_data_offset >= 0) {
             char* code_heap_array = *(char**)(code_heaps + _array_data_offset);
             memcpy(_code_heap, code_heap_array, code_heap_count * sizeof(_code_heap[0]));
         }

--- a/src/vmStructs.h
+++ b/src/vmStructs.h
@@ -109,7 +109,7 @@ class VMStructs {
     static const char* _flags_addr;
     static int _flag_count;
     static int _flag_size;
-    static char* _code_heap[3];
+    static char* _code_heap[4];
     static const void* _code_heap_low;
     static const void* _code_heap_high;
     static char** _code_heap_addr;
@@ -595,6 +595,7 @@ class CodeHeap : VMStructs {
         if (contains(_code_heap[0], pc)) return findNMethod(_code_heap[0], pc);
         if (contains(_code_heap[1], pc)) return findNMethod(_code_heap[1], pc);
         if (contains(_code_heap[2], pc)) return findNMethod(_code_heap[2], pc);
+        if (contains(_code_heap[3], pc)) return findNMethod(_code_heap[3], pc);
         return NULL;
     }
 };

--- a/test/test/vmstructs/DoBusyWork.java
+++ b/test/test/vmstructs/DoBusyWork.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.vmstructs;
+
+import java.util.ArrayList;
+import java.util.Random;
+
+public class DoBusyWork {
+    public static void main(String[] args) {
+        ArrayList<Integer> collectedNumbers = new ArrayList<>();
+        for (int i = 0; i < 10; ++i) {
+            ArrayList<Integer> numbers = doBusyWork();
+            collectedNumbers.addAll(numbers);
+        }
+        collectedNumbers.sort(null);
+    }
+
+    public static ArrayList<Integer> doBusyWork() {
+        long seed = System.currentTimeMillis();
+        Random random = new Random(seed);
+        ArrayList<Integer> numbers = new ArrayList<>();
+        for (int i = 0; i < 1000000; i++) {
+            numbers.add(random.nextInt());
+        }
+        numbers.sort(null);
+        return numbers;
+    }
+}

--- a/test/test/vmstructs/VmstructsTests.java
+++ b/test/test/vmstructs/VmstructsTests.java
@@ -6,6 +6,7 @@
 package test.vmstructs;
 
 import one.profiler.test.Assert;
+import one.profiler.test.Jvm;
 import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
@@ -32,5 +33,21 @@ public class VmstructsTests {
     public void checkJni(TestProcess p) throws Exception {
         p.waitForExit();
         Assert.isEqual(p.exitCode(), 0);
+    }
+
+    @Test(
+        mainClass = DoBusyWork.class,
+        agentArgs = "start,event=cpu,collapsed,interval=1ms,file=%f",
+        jvmArgs = "-XX:+UnlockExperimentalVMOptions -XX:+HotCodeHeap -XX:+NMethodRelocation -XX:HotCodeIntervalSeconds=0 -XX:HotCodeSampleSeconds=1 -XX:HotCodeStablePercent=-1 -XX:HotCodeStartupDelaySeconds=0",
+        jvm = Jvm.HOTSPOT,
+        jvmVer = {27, Integer.MAX_VALUE},
+        runIsolated = true
+    )
+    public void checkHotCodeHeap(TestProcess p) throws Exception {
+        Output out = p.waitForExit("%f");
+        assert out.contains("DoBusyWork\\.main");
+        assert out.contains("DoBusyWork\\.doBusyWork");
+        assert !out.contains("unknown_nmethod");
+        assert !out.contains("no_Java_frame");
     }
 }


### PR DESCRIPTION
### Description
Adds support for HotCodeHeap by increasing the number of code caches from 3 to 4

### Related issues


### Motivation and context
https://bugs.openjdk.org/browse/JDK-8328186

### How has this been tested?
Profile an application with the hot code heap enabled. Before this change, entries will appear in the profile as
`[unknown_nmethod]` and `[no_Java_frame]`. After this change, they appear correctly. The included unit test recreates this and asserts on the behavior.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
