### PR TITLE
Clear customEvents between chunks

### DIFF
--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -65,6 +65,18 @@ public class JfrReader implements Closeable {
 
     private final Dictionary<Constructor<? extends Event>> customEvents = new Dictionary<>();
 
+    private final Map<String, Class<? extends Event>> registeredEvents = new HashMap<>();
+
+    // The following classes are instantiated reflectively.
+    // Make sure to list them in reachability-metadata.json.
+    {
+        registeredEvents.put("jdk.CPULoad", CPULoad.class);
+        registeredEvents.put("jdk.GCHeapSummary", GCHeapSummary.class);
+        registeredEvents.put("jdk.ObjectCount", ObjectCount.class);
+        registeredEvents.put("jdk.ObjectCountAfterGC", ObjectCount.class);
+        registeredEvents.put("profiler.ProcessSample", ProcessSample.class);
+    }
+
     private int executionSample;
     private int nativeMethodSample;
     private int wallClockSample;
@@ -129,6 +141,7 @@ public class JfrReader implements Closeable {
     }
 
     public <E extends Event> void registerEvent(String name, Class<E> eventClass) {
+        registeredEvents.put(name, eventClass);
         JfrClass type = typesByName.get(name);
         if (type != null) {
             try {
@@ -617,13 +630,9 @@ public class JfrReader implements Closeable {
         cpuTimeSample = getTypeId("jdk.CPUTimeSample");
         nativeLock = getTypeId("profiler.NativeLock");
 
-        // The following classes are instantiated reflectively.
-        // Make sure to list them in reachability-metadata.json.
-        registerEvent("jdk.CPULoad", CPULoad.class);
-        registerEvent("jdk.GCHeapSummary", GCHeapSummary.class);
-        registerEvent("jdk.ObjectCount", ObjectCount.class);
-        registerEvent("jdk.ObjectCountAfterGC", ObjectCount.class);
-        registerEvent("profiler.ProcessSample", ProcessSample.class);
+        for (Map.Entry<String, Class<? extends Event>> e: registeredEvents.entrySet()) {
+            registerEvent(e.getKey(), e.getValue());
+        }
 
         JfrClass wallClass = typesByName.get("profiler.WallClockSample");
         hasWallTimeSpan = wallClass != null && wallClass.field("timeSpan") != null;

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -64,18 +64,7 @@ public class JfrReader implements Closeable {
     public final Map<String, Map<Integer, String>> enums = new HashMap<>();
 
     private final Dictionary<Constructor<? extends Event>> customEvents = new Dictionary<>();
-
-    private final Map<String, Class<? extends Event>> registeredEvents = new HashMap<>();
-
-    // The following classes are instantiated reflectively.
-    // Make sure to list them in reachability-metadata.json.
-    {
-        registeredEvents.put("jdk.CPULoad", CPULoad.class);
-        registeredEvents.put("jdk.GCHeapSummary", GCHeapSummary.class);
-        registeredEvents.put("jdk.ObjectCount", ObjectCount.class);
-        registeredEvents.put("jdk.ObjectCountAfterGC", ObjectCount.class);
-        registeredEvents.put("profiler.ProcessSample", ProcessSample.class);
-    }
+    private final Map<String, Class<? extends Event>> customEventsByName = new HashMap<>();
 
     private int executionSample;
     private int nativeMethodSample;
@@ -141,7 +130,11 @@ public class JfrReader implements Closeable {
     }
 
     public <E extends Event> void registerEvent(String name, Class<E> eventClass) {
-        registeredEvents.put(name, eventClass);
+        customEventsByName.put(name, eventClass);
+        registerCustomEvent(name, eventClass);
+    }
+
+    private <E extends Event> void registerCustomEvent(String name, Class<E> eventClass) {
         JfrClass type = typesByName.get(name);
         if (type != null) {
             try {
@@ -149,6 +142,22 @@ public class JfrReader implements Closeable {
             } catch (NoSuchMethodException e) {
                 throw new IllegalArgumentException("No suitable constructor found");
             }
+        }
+    }
+
+    private void registerCustomEvents() {
+        customEvents.clear();
+
+        // The following classes are instantiated reflectively.
+        // Make sure to list them in reachability-metadata.json.
+        registerCustomEvent("jdk.CPULoad", CPULoad.class);
+        registerCustomEvent("jdk.GCHeapSummary", GCHeapSummary.class);
+        registerCustomEvent("jdk.ObjectCount", ObjectCount.class);
+        registerCustomEvent("jdk.ObjectCountAfterGC", ObjectCount.class);
+        registerCustomEvent("profiler.ProcessSample", ProcessSample.class);
+
+        for (Map.Entry<String, Class<? extends Event>> entry : customEventsByName.entrySet()) {
+            registerCustomEvent(entry.getKey(), entry.getValue());
         }
     }
 
@@ -370,11 +379,11 @@ public class JfrReader implements Closeable {
 
         types.clear();
         typesByName.clear();
-        customEvents.clear();
 
         readMeta(chunkStart + metaOffset);
         readConstantPool(chunkStart + cpOffset);
         cacheEventTypes();
+        registerCustomEvents();
 
         seek(chunkStart + CHUNK_HEADER_SIZE);
         state = STATE_READING;
@@ -629,10 +638,6 @@ public class JfrReader implements Closeable {
         free = getTypeId("profiler.Free");
         cpuTimeSample = getTypeId("jdk.CPUTimeSample");
         nativeLock = getTypeId("profiler.NativeLock");
-
-        for (Map.Entry<String, Class<? extends Event>> e: registeredEvents.entrySet()) {
-            registerEvent(e.getKey(), e.getValue());
-        }
 
         JfrClass wallClass = typesByName.get("profiler.WallClockSample");
         hasWallTimeSpan = wallClass != null && wallClass.field("timeSpan") != null;

--- a/src/converter/one/jfr/JfrReader.java
+++ b/src/converter/one/jfr/JfrReader.java
@@ -357,6 +357,7 @@ public class JfrReader implements Closeable {
 
         types.clear();
         typesByName.clear();
+        customEvents.clear();
 
         readMeta(chunkStart + metaOffset);
         readConstantPool(chunkStart + cpOffset);


### PR DESCRIPTION
### Description

Add `customEvents.clear()` alongside `types.clear()` and `typesByName.clear()` when `JfrReader` moves to the next chunk. `customEvents` is keyed by chunk-scoped JFR type ID's (`typesByName()`), and without clearing it on new chunks, it can become stale. 

### Related issues


### Motivation and context


### How has this been tested?


### Caveat 

This adds a burden to the caller for custom events. After this change, an entry added by an external caller is wiped at every chunk boundary, because `cacheEventTypes()` only re-registers the events hardcoded in `JfrReader`. Callers that register custom events in multi-chunk recordings will need to re-call `registerEvent` after each chunk. 

If that is acceptable, I think the patch solves the stale ID problem. If not, I can add a implementation to store, and re-register custom events if you think its the responsiblity of `JfrReader` to do it.


---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
