### PR TITLE
Flush wall clock events on dump or jfr chunk rotation

### DIFF
--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1114,6 +1114,7 @@ Error Profiler::flushJfr() {
     updateJavaThreadNames();
     updateNativeThreadNames();
 
+    if (_event_mask & EM_WALL) wall_clock.flush();
     lockAll();
     _jfr.flush();
     unlockAll();
@@ -1132,6 +1133,7 @@ Error Profiler::dump(Writer& out, Arguments& args) {
     if (_state == RUNNING) {
         updateJavaThreadNames();
         updateNativeThreadNames();
+        if (_event_mask & EM_WALL) wall_clock.flush();
     }
 
     switch (args._output) {

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -1113,8 +1113,8 @@ Error Profiler::flushJfr() {
 
     updateJavaThreadNames();
     updateNativeThreadNames();
-
     if (_event_mask & EM_WALL) wall_clock.flush();
+
     lockAll();
     _jfr.flush();
     unlockAll();

--- a/src/wallClock.cpp
+++ b/src/wallClock.cpp
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <map>
 #include <string.h>
 #include <unistd.h>
 #include <sys/types.h>
 #include "wallClock.h"
+#include "mutex.h"
 #include "profiler.h"
 #include "stackFrame.h"
 #include "tsc.h"
@@ -99,6 +101,8 @@ class ThreadCpuTimeBuffer {
 };
 
 static ThreadCpuTimeBuffer _thread_cpu_time_buf;
+static ThreadSleepMap _thread_sleep_state;
+static Mutex _thread_sleep_state_lock;
 
 
 long WallClock::_interval;
@@ -185,13 +189,24 @@ void WallClock::stop() {
     pthread_join(_thread, NULL);
 }
 
+void WallClock::flush() {
+    if (_mode != WALL_BATCH) return;
+
+    MutexLocker ml(_thread_sleep_state_lock);
+    for (ThreadSleepMap::iterator it = _thread_sleep_state.begin(); it != _thread_sleep_state.end(); ++it) {
+        if (it->second.counter != 0) {
+            recordWallClock(it->second, THREAD_SLEEPING, it->first);
+            it->second.counter = 0;
+        }
+    }
+}
+
 void WallClock::timerLoop() {
     int self = OS::threadId();
     ThreadFilter* thread_filter = Profiler::instance()->threadFilter();
     bool thread_filter_enabled = thread_filter->enabled();
     Mode mode = _mode;
 
-    ThreadSleepMap thread_sleep_state;
     ThreadList* thread_list = OS::listThreads();
     _thread_cpu_time_buf.reset();
     u64 cycle_start_time = OS::nanotime();
@@ -214,7 +229,8 @@ void WallClock::timerLoop() {
                     continue;
                 }
             } else if (mode == WALL_BATCH) {
-                ThreadSleepState& tss = thread_sleep_state[thread_id];
+                MutexLocker ml(_thread_sleep_state_lock);
+                ThreadSleepState& tss = _thread_sleep_state[thread_id];
                 u64 new_thread_cpu_time = enabled ? OS::threadCpuTime(thread_id) : 0;
                 if (new_thread_cpu_time != 0 && new_thread_cpu_time - tss.last_cpu_time <= RUNNABLE_THRESHOLD_NS) {
                     tss.last_time = TSC::ticks();
@@ -254,16 +270,12 @@ void WallClock::timerLoop() {
         }
 
         // Sync thread CPU times updated since the previous iteration
-        _thread_cpu_time_buf.drain(thread_sleep_state);
+        MutexLocker ml(_thread_sleep_state_lock);
+        _thread_cpu_time_buf.drain(_thread_sleep_state);
     }
 
     delete thread_list;
 
-    // Flush remaining WallClock batches
-    for (ThreadSleepMap::const_iterator it = thread_sleep_state.begin(); it != thread_sleep_state.end(); ++it) {
-        const ThreadSleepState& tss = it->second;
-        if (tss.counter != 0) {
-            recordWallClock(tss, THREAD_SLEEPING, it->first);
-        }
-    }
+    flush();
+    _thread_sleep_state.clear();
 }

--- a/src/wallClock.h
+++ b/src/wallClock.h
@@ -57,6 +57,7 @@ class WallClock : public Engine {
 
     Error start(Arguments& args);
     void stop();
+    void flush();
 };
 
 #endif // _WALLCLOCK_H

--- a/test/test/wall/WallFlushApp.java
+++ b/test/test/wall/WallFlushApp.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright The async-profiler authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package test.wall;
+
+import java.util.concurrent.CountDownLatch;
+
+import one.profiler.AsyncProfiler;
+
+public class WallFlushApp {
+
+    public static void main(String[] args) throws Exception {
+        CountDownLatch release = new CountDownLatch(1);
+        Thread worker = new Thread(() -> {
+            try {
+                release.await();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }, "WallFlushSleeper");
+        worker.start();
+
+        Thread.sleep(1000);
+
+        AsyncProfiler.getInstance().execute("dump,jfr");
+
+        release.countDown();
+        worker.join();
+    }
+}

--- a/test/test/wall/WallTests.java
+++ b/test/test/wall/WallTests.java
@@ -5,10 +5,14 @@
 
 package test.wall;
 
-import one.profiler.test.Output;
+import one.jfr.JfrReader;
+import one.jfr.event.ExecutionSample;
 import one.profiler.test.Assert;
+import one.profiler.test.Output;
 import one.profiler.test.Test;
 import one.profiler.test.TestProcess;
+
+import java.util.List;
 
 public class WallTests {
 
@@ -25,5 +29,28 @@ public class WallTests {
         long s3 = out.samples("test/wall/IdleClient.run");
         assert s1 > 10 && s2 > 10 && s3 > 10;
         assert Math.abs(s1 - s2) < 5 && Math.abs(s2 - s3) < 5 && Math.abs(s3 - s1) < 5;
+    }
+
+    // Regression test for #1249
+    @Test(mainClass = WallFlushApp.class, agentArgs = "start,wall=50ms,jfr,file=%f.jfr")
+    public void flushBufferedSleepingSamples(TestProcess p) throws Exception {
+        p.waitForExit();
+        assert p.exitCode() == 0;
+
+        int sleepingSamples = 0;
+        try (JfrReader jfr = new JfrReader(p.getFilePath("%f"))) {
+            jfr.stopAtNewChunk = true;
+            List<ExecutionSample> events = jfr.readAllEvents(ExecutionSample.class);
+            int sleepingState = jfr.getEnumKey("jdk.types.ThreadState", "STATE_SLEEPING");
+            assert sleepingState >= 0 : "STATE_SLEEPING enum not found in JFR";
+            for (ExecutionSample e : events) {
+                if (e.threadState == sleepingState
+                        && "WallFlushSleeper".equals(jfr.threads.get(e.tid))) {
+                    sleepingSamples += e.samples;
+                }
+            }
+        }
+
+        Assert.isGreater(sleepingSamples, 5);
     }
 }


### PR DESCRIPTION


### Description

Flush pending WallClock events when the user requests a dump or when the jfr chunk rotates, to prevent dropped samples described in the issue

### Related issues

Fixes #1249

### Motivation and context


### How has this been tested?

Included unit tests based on the reproducer posted to the related issue

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
