### PR TITLE
Fix binary size comparison workflow to not rely on eventually-consistent APIs

### DIFF
--- a/.github/workflows/compare-binary-sizes.yml
+++ b/.github/workflows/compare-binary-sizes.yml
@@ -10,7 +10,9 @@ permissions:
 env:
   GH_TOKEN: "${{ github.token }}"
   REPO: "${{ github.repository }}"
-  PR_SHA: "${{ github.event.workflow_run.head_sha }}"
+  PR_CI_RUN_ID: "${{ github.event.workflow_run.id }}"
+  HEAD_OWNER: "${{ github.event.workflow_run.head_repository.owner.login }}"
+  HEAD_BRANCH: "${{ github.event.workflow_run.head_branch }}"
 jobs:
   compare:
     if: ${{ github.event.workflow_run.event == 'pull_request' }}
@@ -18,11 +20,12 @@ jobs:
     steps:
       - run: |
           gh api "repos/${REPO}/contents/scripts/compare-binary-sizes.sh" -H 'Accept: application/vnd.github.raw' > compare.sh
-          read pr base_sha < <(gh api "repos/${REPO}/commits/${PR_SHA}/pulls" --jq '.[0] | "\(.number) \(.base.sha)"')
+          read pr base_sha < <(gh api "repos/${REPO}/pulls?head=${HEAD_OWNER}:${HEAD_BRANCH}&state=open" --jq '.[0] | "\(.number) \(.base.sha)"')
+          base_run_id=$(gh api "repos/${REPO}/actions/runs?head_sha=${base_sha}&event=push" --jq '[.workflow_runs[] | select(.name == "CI")] | .[0].id')
           function find-archive() { find "${1}" -type f \( -name "async-profiler-*${2}.tar.gz" -o -name "async-profiler-*${2}.zip" \) ! -name '*-debug*' | head -n1; }
           for p in linux-x64 linux-arm64 macos; do
-            gh run download -R "${REPO}" -n "async-profiler-${p}-${base_sha:0:7}" -D "base/${p}" 2>/dev/null || continue
-            gh run download -R "${REPO}" -n "async-profiler-${p}-${PR_SHA:0:7}"   -D "pr/${p}"   2>/dev/null || continue
+            gh run download -R "${REPO}" "${base_run_id}"    -n "async-profiler-${p}-${base_sha:0:7}" -D "base/${p}" || continue
+            gh run download -R "${REPO}" "${PR_CI_RUN_ID}"   -p "async-profiler-${p}-*"               -D "pr/${p}"   || continue
             bash compare.sh "$(find-archive "base/${p}" "${p}")" "$(find-archive "pr/${p}" "${p}")" >> report.md
           done
           gh pr comment "${pr}" -R "${REPO}" --body-file report.md --edit-last --create-if-none


### PR DESCRIPTION
### Description
The previous iteration of this workflow may fail due to delays in `gh api` calls described on [this stackoverflow post](https://stackoverflow.com/questions/77703104/how-long-does-it-take-for-github-api-to-refresh-the-data-after-being-changed-in). While I haven't found anything in official docs stating the new version will not encounter this error, it seems to work in practice

### Related issues
See failing size comparison workflows such as [this one](https://github.com/async-profiler/async-profiler/actions/runs/26113735751)

### Motivation and context


### How has this been tested?
On my [fork](https://github.com/benty-amzn/async-profiler/pull/3#issuecomment-4490515036) with a test PR

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
