### PR TITLE
Prefer non-real-time signals for profiling

### DIFF
--- a/src/os_linux.cpp
+++ b/src/os_linux.cpp
@@ -286,11 +286,19 @@ SigAction OS::replaceCrashHandler(SigAction action) {
     return old_action;
 }
 
+// Prefer standard signals, because they don't queue up, unlike real-time signals
+static int nextAllowedSignal(int signo) {
+    switch (signo) {
+        case SIGPROF:   return SIGVTALRM;
+        case SIGVTALRM: return SIGSTKFLT;
+        case SIGSTKFLT: return SIGPWR;
+        case SIGPWR:    return SIGRTMIN;
+        default:        return signo < SIGRTMAX ? signo + 1 : SIGPROF;
+    }
+}
+
 int OS::getProfilingSignal(int mode) {
     static int preferred_signals[2] = {SIGPROF, SIGVTALRM};
-
-    const u64 allowed_signals =
-        1ULL << SIGPROF | 1ULL << SIGVTALRM | 1ULL << SIGSTKFLT | 1ULL << SIGPWR | -(1ULL << SIGRTMIN);
 
     int& signo = preferred_signals[mode];
     int initial_signo = signo;
@@ -298,12 +306,12 @@ int OS::getProfilingSignal(int mode) {
 
     do {
         struct sigaction sa;
-        if ((allowed_signals & (1ULL << signo)) != 0 && signo != other_signo && sigaction(signo, NULL, &sa) == 0) {
+        if (signo != other_signo && sigaction(signo, NULL, &sa) == 0) {
             if (sa.sa_handler == SIG_DFL || sa.sa_handler == SIG_IGN || sa.sa_sigaction == installed_sigaction[signo]) {
                 return signo;
             }
         }
-    } while ((signo = (signo + 53) & 63) != initial_signo);
+    } while ((signo = nextAllowedSignal(signo)) != initial_signo);
 
     return signo;
 }


### PR DESCRIPTION
### Description

Change the order in which profiling signals are selected.
Standard (non-real-time) signals come first:

SIGPROF → SIGVTALRM → SIGSTKFLT → SIGPWR → SIGRTMIN...SIGRTMAX

### Motivation and context

Alternate profiling signals (other than the default SIGPROF/SIGVTALRM) are needed for the case when two or more instances of async-profiler are running simultaneously (#759). There are two more standard signals that are generally unused on Linux: SIGSTKFLT and SIGPWR. We will prefer these signals, because, unlike real-time signals, they are not queued. In a pathological case (e.g. one thread blocks a real-time signal that async-profiler uses), wall-clock profiler may end up growing pending signal queue until it exceeds the limit.

### How has this been tested?

Ran 2 or 3 instances of async-profiler on the same process simultaneously. All were running fine and produced meaningful results.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
