### PR TITLE
Fixed visualization of native methods on the Heatmap

### DIFF
--- a/src/res/heatmap.html
+++ b/src/res/heatmap.html
@@ -965,9 +965,6 @@
 		if (className === '') {
 			return methodName + locationSuffix;
 		}
-		if (type >= 3 && type <= 5) {
-			return methodName + locationSuffix;
-		}
 
 		return className + "." + methodName + locationSuffix;
 	}
@@ -989,11 +986,11 @@
 			const line = data.nextInt18();
 			const type = data.nextInt6();
 
-			const noline = bci === 0xffff && line === 0xffff;
+			const isNative = type >= 3 && type <= 5;
 
-			names.push(methodName(cpool[className], cpool[name], noline ? 0 : bci, noline ? 0 : line, type));
+			names.push(methodName(cpool[className], cpool[name], bci === 0xffff ? 0 : bci, line === 0xffff ? 0 : line, type));
 			colors.push(getColorStable(palette[type], i + 1));
-			bcis[i + 1] = noline ? "" : ", bci: " + bci;
+			bcis[i + 1] = isNative || bci === 0xffff ? "" : ", bci: " + bci;
 		}
 
 		return {n: names, c: colors, b: bcis};


### PR DESCRIPTION
### Description

Fix inaccuracies in displaying Java native methods and non-Java frames:
1. On a heatmap generated from JDK Flight Recording, Java native methods are shown without class name.
2. For Java native methods, line number is shown as 65535.
3. For non-Java native frames, bci is displayed as 0 in a tooltip.

**Before**

<img width="1049" height="424" alt="before" src="https://github.com/user-attachments/assets/e46bf4a0-def7-477f-bc76-8716b9f8a532" />

**After**

<img width="1051" height="466" alt="after" src="https://github.com/user-attachments/assets/7b9085b0-899b-4a3b-bc34-77e3162af6d1" />

### How has this been tested?

Produced two heatmaps from the JDK Flight Recording and from async-profiler recording:
```
jfrconv -o heatmap --threads jdk.jfr
jfrconv -o heatmap --threads asprof.jfr
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license].

[Apache 2.0 license]: https://www.apache.org/licenses/LICENSE-2.0
